### PR TITLE
feat: add CI/CD workflow and prod configuration

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -49,4 +49,5 @@ jobs:
           script: |
             cd ~/ongil-backend
             docker-compose pull
+            docker-compose down
             docker-compose up -d

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -21,8 +21,11 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
+      - name: Test with Gradle
+        run: ./gradlew test
+
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,47 @@
+name: CI - Build and Push Docker Image
+
+on:
+  push:
+    branches: [ "main" ]   # main 브랜치에 push될 때마다 실행
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. 소스 체크아웃
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2. JDK 17 설정 (Gradle 빌드용)
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 3. Gradle wrapper 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # 4. Spring Boot JAR 빌드
+      - name: Build Spring Boot jar
+        run: ./gradlew clean bootJar
+
+      # 5. Docker Hub 로그인
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # 6. Docker 이미지 빌드 + Docker Hub로 push
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            neibler/ongil-backend:latest
+            neibler/ongil-backend:${{ github.sha }}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,47 +1,52 @@
-name: CI - Build and Push Docker Image
+name: CI/CD - Build, Push, Deploy
 
 on:
   push:
-    branches: [ "main" ]   # main 브랜치에 push될 때마다 실행
+    branches: [ "develop" ]
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. 소스 체크아웃
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
 
-      # 2. JDK 17 설정 (Gradle 빌드용)
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      # 3. Gradle wrapper 실행 권한 부여
       - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        run: chmod +x ./gradlew
 
-      # 4. Spring Boot JAR 빌드
-      - name: Build Spring Boot jar
-        run: ./gradlew clean bootJar
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test
 
-      # 5. Docker Hub 로그인
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 6. Docker 이미지 빌드 + Docker Hub로 push
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        run: |
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/ongil-backend:latest .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/ongil-backend:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy on EC2
+        uses: appleboy/ssh-action@v1.0.3
         with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: |
-            neibler/ongil-backend:latest
-            neibler/ongil-backend:${{ github.sha }}
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd ~/ongil-backend
+            docker-compose pull
+            docker-compose up -d

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# 1. JDK가 들어 있는 기본 이미지 사용 (21 LTS)
+FROM eclipse-temurin:21-jdk
+
+# 2. 빌드된 JAR 파일을 컨테이너 안으로 복사
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+# 3. 컨테이너가 노출할 포트 (Spring Boot 기본 8080)
+EXPOSE 8081
+
+# 4. 컨테이너 시작 시 실행할 명령
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     restart: always
     environment:
       SPRING_PROFILES_ACTIVE: prod           # prod 프로필 사용
-      DB_PASSWORD: ${DB_PASSWORD}            # RDS 비밀번호 (prod.env에서 읽음)
     ports:
       - "8081:8081"
     env_file:
-      - ./env/prod.env                       # 서버 전용 비밀번호 저장 파일
+      - ./env/prod.env                       # 서버 전용 비밀번호 및 기타 설정 저장 파일

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  backend:
+    image: neibler/ongil-backend:latest      # 또는 chj78/ongil-backend:latest
+    container_name: ongil-backend
+    restart: always
+    environment:
+      SPRING_PROFILES_ACTIVE: prod           # prod 프로필 사용
+      DB_PASSWORD: ${DB_PASSWORD}            # RDS 비밀번호 (prod.env에서 읽음)
+    ports:
+      - "8081:8081"
+    env_file:
+      - ./env/prod.env                       # 서버 전용 비밀번호 저장 파일

--- a/src/main/java/com/ongil/backend/PingController.java
+++ b/src/main/java/com/ongil/backend/PingController.java
@@ -1,0 +1,13 @@
+package com.ongil.backend;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PingController {
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/main/java/com/ongil/backend/PingController.java
+++ b/src/main/java/com/ongil/backend/PingController.java
@@ -8,6 +8,6 @@ public class PingController {
 
     @GetMapping("/ping")
     public String ping() {
-        return "pong";
+        return "pong2";
     }
 }

--- a/src/main/java/com/ongil/backend/config/SecurityConfig.java
+++ b/src/main/java/com/ongil/backend/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.ongil.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf(csrf -> csrf.disable()) // csrf().disable() 신버전 문법
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/ping").permitAll()  // 오류 없이 허용
+                        .anyRequest().permitAll()              // 임시로 전체 허용
+                )
+                .formLogin(form -> form.disable()); // 기본 /login 페이지 비활성화
+
+        return http.build();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,20 +1,16 @@
 spring:
-  config:
-    activate:
-      on-profile: local
-    import: optional:file:.env[.properties]
-
   datasource:
-    url: ${LOCAL_DB_URL}
-    username: ${LOCAL_DB_USERNAME}
-    password: ${LOCAL_DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
+    url: jdbc:h2:mem:ongil;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
+
+  # optional: open-in-view 경고 없애고 싶으면
+  jpa.open-in-view: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,16 +1,20 @@
 spring:
+  config:
+    activate:
+      on-profile: local
+    import: optional:file:env/local.env[.properties]
+
   datasource:
-    url: jdbc:h2:mem:ongil;MODE=MySQL
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         format_sql: true
-
-  # optional: open-in-view 경고 없애고 싶으면
-  jpa.open-in-view: false
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:mysql://ongil-rds.c7muoime6pde.ap-northeast-2.rds.amazonaws.com:3306/ongil?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ongil_user        # RDS 만들 때 설정한 사용자
+    password: ${DB_PASSWORD}    # 비밀번호는 환경변수로 받기
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+
+server:
+  port: 8081

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,6 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
 
 server:
   port: 8081

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,4 +5,4 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
 
 server:
-  port: 8080
+  port: 8081


### PR DESCRIPTION
- GitHub Actions 워크플로 추가: `.github/workflows/docker-ci.yml`
  - develop 브랜치 push 시 Docker 이미지 빌드 및 Docker Hub(neibler/ongil-backend) 푸시
  - EC2(3.38.199.67)로 배포 자동화

- `application-prod.yml` 설정
  - RDS(MySQL) 접속 정보
  - Hibernate MySQLDialect 명시
  - 서버 포트 8081 지정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /ping health check endpoint.

* **Chores**
  * Added Docker containerization and docker-compose setup for deployment.
  * Added CI/CD workflow for automated build, image push, and remote deployment.
  * Added H2 runtime dependency and production configuration.
  * Changed server port to 8081 and added production environment settings.
  * Updated security configuration to allow the health endpoint and simplified CSRF/login behavior.
  * Updated .gitignore to exclude environment files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->