### PR TITLE
[Feat] 일반 로그인 구현

### DIFF
--- a/src/main/java/com/ongil/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ongil/backend/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ongil.backend.domain.auth.dto.request.LoginReqDto;
 import com.ongil.backend.domain.auth.dto.request.TokenRefreshReqDto;
 import com.ongil.backend.domain.auth.dto.response.AuthResDto;
 import com.ongil.backend.domain.auth.dto.response.TokenRefreshResDto;
@@ -21,6 +22,7 @@ import com.ongil.backend.global.common.dto.DataResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +31,21 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
+@Tag(name = "Auth", description = "회원/인증 API")
 public class AuthController {
 
 	private final AuthService authService;
 	private final KakaoLoginService kakaoLoginService;
 	private final GoogleLoginService googleLoginService;
+
+	@PostMapping("/login")
+	@Operation(summary = "일반 로그인 API", description = "ID와 비밀번호를 받아 JWT 토큰을 발급합니다.")
+	public ResponseEntity<DataResponse<AuthResDto>> login(
+		@Valid @RequestBody LoginReqDto loginReqDto
+	) {
+		AuthResDto res = authService.login(loginReqDto);
+		return ResponseEntity.ok(DataResponse.from(res));
+	}
 
 	@PostMapping("/oauth/kakao")
 	@Operation(summary = "카카오 회원가입/로그인 API", description = "인가코드(code)로 카카오 토큰 교환 후, 우리 서비스 JWT 발급")
@@ -61,6 +73,8 @@ public class AuthController {
 		TokenRefreshResDto res = authService.refreshAccessToken(request.refreshToken());
 		return ResponseEntity.ok(DataResponse.from(res));
 	}
+
+
 
 	@PostMapping("/logout")
 	@Operation(summary = "로그아웃 API", description = "Redis에 저장된 리프레시 토큰을 삭제하여 로그아웃 처리")

--- a/src/main/java/com/ongil/backend/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/ongil/backend/domain/auth/converter/AuthConverter.java
@@ -16,6 +16,8 @@ public class AuthConverter {
 			.refreshToken(refreshToken)
 			.loginType(user.getLoginType())
 			.isNewUser(isNewUser)
+			.profileUrl(user.getProfileImg())
+			.nickName(user.getName())
 			.expires_in((int) (accessExpMs / 1000)) // 초 단위
 			.build();
 	}

--- a/src/main/java/com/ongil/backend/domain/auth/dto/request/LoginReqDto.java
+++ b/src/main/java/com/ongil/backend/domain/auth/dto/request/LoginReqDto.java
@@ -1,0 +1,15 @@
+package com.ongil.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record LoginReqDto(
+	@NotNull(message = "아이디를 입력해주세요.")
+	@Size(min = 4, message = "아이디는 4자 이상이어야 합니다.")
+	String loginId,
+
+	@NotNull(message = "비밀번호를 입력해주세요.")
+	@Size(min = 4, message = "비밀번호는 4자 이상이어야 합니다.")
+	String password
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/auth/dto/request/LoginReqDto.java
+++ b/src/main/java/com/ongil/backend/domain/auth/dto/request/LoginReqDto.java
@@ -1,14 +1,14 @@
 package com.ongil.backend.domain.auth.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record LoginReqDto(
-	@NotNull(message = "아이디를 입력해주세요.")
+	@NotBlank(message = "아이디를 입력해주세요.")
 	@Size(min = 4, message = "아이디는 4자 이상이어야 합니다.")
 	String loginId,
 
-	@NotNull(message = "비밀번호를 입력해주세요.")
+	@NotBlank(message = "비밀번호를 입력해주세요.")
 	@Size(min = 4, message = "비밀번호는 4자 이상이어야 합니다.")
 	String password
 ) {

--- a/src/main/java/com/ongil/backend/domain/auth/dto/response/AuthResDto.java
+++ b/src/main/java/com/ongil/backend/domain/auth/dto/response/AuthResDto.java
@@ -28,6 +28,13 @@ public record AuthResDto(
 	@NotNull
 	Boolean isNewUser,
 
+	@Schema(description = "프로필 이미지")
+	String profileUrl,
+
+	@Schema(description = "이름")
+	@NotNull
+	String nickName,
+
 	@Schema(description = "액세스 토큰 만료 시간")
 	@NotNull
 	Integer expires_in

--- a/src/main/java/com/ongil/backend/domain/auth/entity/LoginType.java
+++ b/src/main/java/com/ongil/backend/domain/auth/entity/LoginType.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum LoginType {
 	GOOGLE("GOOGLE"),
-	KAKAO("KAKAO");
+	KAKAO("KAKAO"),
+	GENERAL("GENERAL");
 
 	private final String value;
 }

--- a/src/main/java/com/ongil/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ongil/backend/domain/auth/service/AuthService.java
@@ -77,16 +77,23 @@ public class AuthService {
 
 		User user;
 		boolean isNewUser = userOptional.isEmpty();
+
 		if (isNewUser) {
-			user = userRepository.save(
-				User.builder()
-					.loginType(LoginType.GENERAL)
-					.loginId(loginReqDto.loginId())
-					.password(passwordEncoder.encode(loginReqDto.password()))
-					.name("일반 로그인 회원")
-					.email(loginReqDto.loginId() + "@test.com")
-					.build()
-			);
+			try {
+				user = userRepository.save(
+					User.builder()
+						.loginType(LoginType.GENERAL)
+						.loginId(loginReqDto.loginId())
+						.password(passwordEncoder.encode(loginReqDto.password()))
+						.name("일반 로그인 회원")
+						.email(loginReqDto.loginId() + "@test.com")
+						.build()
+				);
+			} catch (org.springframework.dao.DataIntegrityViolationException e) {
+				user = userRepository.findByLoginTypeAndLoginId(LoginType.GENERAL, loginReqDto.loginId())
+					.orElseThrow(() -> e);
+				isNewUser = false;
+			}
 		} else {
 			// 아이디 존재 시 패스워드 일치 확인
 			user = userOptional.get();

--- a/src/main/java/com/ongil/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ongil/backend/domain/auth/service/AuthService.java
@@ -1,15 +1,25 @@
 package com.ongil.backend.domain.auth.service;
 
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ongil.backend.domain.auth.converter.AuthConverter;
+import com.ongil.backend.domain.auth.dto.request.LoginReqDto;
+import com.ongil.backend.domain.auth.dto.response.AuthResDto;
 import com.ongil.backend.domain.auth.dto.response.TokenRefreshResDto;
+import com.ongil.backend.domain.auth.entity.LoginType;
+import com.ongil.backend.domain.user.entity.User;
 import com.ongil.backend.domain.user.repository.UserRepository;
 import com.ongil.backend.global.common.exception.AppException;
 import com.ongil.backend.global.common.exception.ErrorCode;
 import com.ongil.backend.global.config.redis.RedisRefreshTokenStore;
 import com.ongil.backend.global.security.jwt.JwtTokenProvider;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -20,6 +30,10 @@ public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RedisRefreshTokenStore refreshTokenStore;
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Value("${jwt.access-expiration-ms}")
+	private long accessExpMs;
 
 	public TokenRefreshResDto refreshAccessToken(String refreshTokenValue) {
 
@@ -55,4 +69,42 @@ public class AuthService {
 		refreshTokenStore.removeRefreshToken(String.valueOf(userId));
 		userRepository.deleteById(userId);
 	}
+
+	@Transactional
+	public AuthResDto login(LoginReqDto loginReqDto) {
+
+		Optional<User> userOptional = userRepository.findByLoginTypeAndLoginId(LoginType.GENERAL, loginReqDto.loginId());
+
+		User user;
+		boolean isNewUser = userOptional.isEmpty();
+		if (isNewUser) {
+			user = userRepository.save(
+				User.builder()
+					.loginType(LoginType.GENERAL)
+					.loginId(loginReqDto.loginId())
+					.password(passwordEncoder.encode(loginReqDto.password()))
+					.name("일반 로그인 회원")
+					.email(loginReqDto.loginId() + "@test.com")
+					.build()
+			);
+		} else {
+			// 아이디 존재 시 패스워드 일치 확인
+			user = userOptional.get();
+			if (!passwordEncoder.matches(loginReqDto.password(), user.getPassword())) {
+				throw new AppException(ErrorCode.INVALID_PASSWORD);
+			}
+		}
+
+		String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+		String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+		refreshTokenStore.saveRefreshToken(
+			String.valueOf(user.getId()),
+			refreshToken,
+			jwtTokenProvider.getRefreshTokenExpireTime()
+		);
+
+		return AuthConverter.toResponse(user, accessToken, refreshToken, isNewUser, accessExpMs);
+	}
+
 }

--- a/src/main/java/com/ongil/backend/domain/auth/service/GoogleLoginService.java
+++ b/src/main/java/com/ongil/backend/domain/auth/service/GoogleLoginService.java
@@ -51,13 +51,13 @@ public class GoogleLoginService {
 			throw new AppException(ErrorCode.INVALID_SOCIAL_USER_INFO);
 		}
 
-		boolean isNewUser = !userRepository.existsByLoginTypeAndSocialId(LoginType.GOOGLE, socialId);
+		boolean isNewUser = !userRepository.existsByLoginTypeAndLoginId(LoginType.GOOGLE, socialId);
 
-		User user = userRepository.findByLoginTypeAndSocialId(LoginType.GOOGLE, socialId)
+		User user = userRepository.findByLoginTypeAndLoginId(LoginType.GOOGLE, socialId)
 			.orElseGet(() -> userRepository.save(
 				User.builder()
 					.loginType(LoginType.GOOGLE)
-					.socialId(socialId)
+					.loginId(socialId)
 					.email(extractEmail(userInfo))
 					.profileImg(extractProfileImg(userInfo))
 					.name(extractName(userInfo))

--- a/src/main/java/com/ongil/backend/domain/auth/service/KakaoLoginService.java
+++ b/src/main/java/com/ongil/backend/domain/auth/service/KakaoLoginService.java
@@ -56,13 +56,13 @@ public class KakaoLoginService {
 		}
 
 		// 신규 유저 확인
-		boolean isNewUser = !userRepository.existsByLoginTypeAndSocialId(LoginType.KAKAO, socialId);
+		boolean isNewUser = !userRepository.existsByLoginTypeAndLoginId(LoginType.KAKAO, socialId);
 
-		User user = userRepository.findByLoginTypeAndSocialId(LoginType.KAKAO, socialId)
+		User user = userRepository.findByLoginTypeAndLoginId(LoginType.KAKAO, socialId)
 			.orElseGet(() -> userRepository.save(
 				User.builder()
 					.loginType(LoginType.KAKAO)
-					.socialId(socialId)
+					.loginId(socialId)
 					.email(extractEmail(userInfo))
 					.profileImg(extractProfileImg(userInfo))
 					.name(extractNickname(userInfo))

--- a/src/main/java/com/ongil/backend/domain/user/entity/User.java
+++ b/src/main/java/com/ongil/backend/domain/user/entity/User.java
@@ -14,10 +14,10 @@ import lombok.*;
 @Table(
 	name = "users",
 	indexes = { // 조회 성능 향상
-		@Index(name = "idx_login_type_social_id", columnList = "login_type,social_id")
+		@Index(name = "idx_login_type_social_id", columnList = "login_type,login_id")
 	},
 	uniqueConstraints = { // 중복 가입 방지
-		@UniqueConstraint(name = "uk_login_type_social_id", columnNames = {"login_type", "social_id"})
+		@UniqueConstraint(name = "uk_login_type_social_id", columnNames = {"login_type", "login_id"})
 	}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,8 +35,12 @@ public class User extends BaseEntity {
 	@Column(name = "login_type", nullable = false)
 	private LoginType loginType;
 
-	@Column(name = "social_id", nullable = false)
-	private String socialId;
+	// 일반로그인 ID 또는 소셜 고유 ID
+	@Column(name = "login_id", nullable = false)
+	private String loginId;
+
+	@Column(name = "password")
+	private String password;
 
 	@Column(nullable = false, unique = true, length = 100)
 	private String email;

--- a/src/main/java/com/ongil/backend/domain/user/entity/User.java
+++ b/src/main/java/com/ongil/backend/domain/user/entity/User.java
@@ -14,10 +14,10 @@ import lombok.*;
 @Table(
 	name = "users",
 	indexes = { // 조회 성능 향상
-		@Index(name = "idx_login_type_social_id", columnList = "login_type,login_id")
+		@Index(name = "idx_login_type_login_id", columnList = "login_type, login_id")
 	},
 	uniqueConstraints = { // 중복 가입 방지
-		@UniqueConstraint(name = "uk_login_type_social_id", columnNames = {"login_type", "login_id"})
+		@UniqueConstraint(name = "uk_login_type_login_id", columnNames = {"login_type", "login_id"})
 	}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/ongil/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ongil/backend/domain/user/repository/UserRepository.java
@@ -8,10 +8,10 @@ import com.ongil.backend.domain.auth.entity.LoginType;
 import com.ongil.backend.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-	Optional<User> findByLoginTypeAndSocialId(
+	Optional<User> findByLoginTypeAndLoginId(
 		LoginType loginType,
 		String socialId
 	);
 
-	boolean existsByLoginTypeAndSocialId(LoginType loginType, String socialId);
+	boolean existsByLoginTypeAndLoginId(LoginType loginType, String loginId);
 }

--- a/src/main/java/com/ongil/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ongil/backend/domain/user/repository/UserRepository.java
@@ -10,7 +10,7 @@ import com.ongil.backend.domain.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByLoginTypeAndLoginId(
 		LoginType loginType,
-		String socialId
+		String loginId
 	);
 
 	boolean existsByLoginTypeAndLoginId(LoginType loginType, String loginId);

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 	REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 존재하지 않습니다.", "AUTH-002"),
 	STOLEN_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "탈취된 토큰으로 의심됩니다. 다시 로그인해주세요.", "AUTH-003"),
 	INVALID_SOCIAL_USER_INFO(HttpStatus.BAD_REQUEST, "사용자 정보가 올바르지 않습니다.", "AUTH-004"),
+	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.", "AUTH-005"),
 
 	// USER
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.", "USER-001"),

--- a/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -46,5 +48,10 @@ public class SecurityConfig {
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
 	}
 }


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #22 
* 스웨거(Swagger) 테스트 편리성을 위한 일반 로그인 로직 구현

## ✨ 상세 설명
* **일반 로그인 로직 구현**:
    * 테스트 편의성을 위해 아이디가 DB에 없을 시 자동으로 가입되고, 있을 시 비밀번호를 검증하는 일반 로그인 로직을 구현했습니다.
    * `passwordEncoder.matches()`를 사용하여 암호화된 비밀번호 비교 로직을 적용했습니다.
* **유저 엔티티(`User`) 관련 변경**:
    * 일반 로그인 유저도 생김에 따라, 기존 `social_id` 컬럼명을 `login_id`로 변경하고 관련 매핑을 정리했습니다. (일반 로그인 유저의 경우 유저가 설정한 ID, 소셜 로그인 유저의 경우 카카오/구글에서 발급해주는 소셜 고유 ID가 들어가게됨)
    

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)
<img width="539" height="709" alt="스크린샷 2026-01-13 오후 3 37 41" src="https://github.com/user-attachments/assets/3b2da7b1-6829-4f96-b7c5-5aac68da511d" />

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 아이디/비밀번호 기반 일반 로그인(POST /auth/login) 추가
  * 로그인 응답에 프로필 이미지 URL 및 닉네임 포함
  * 로그인 API에 Swagger 문서화 태그 추가

* **개선**
  * 소셜 로그인 흐름 정비(로그인 식별자 통일)
  * 비밀번호 암호화 및 토큰 갱신 처리 강화

* **버그/오류 처리**
  * 잘못된 비밀번호에 대한 명확한 오류 응답 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->