### PR TITLE
Feat: 회원 체형 정보 조회/저장 API 구현

### DIFF
--- a/src/main/java/com/ongil/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/ongil/backend/domain/user/controller/UserController.java
@@ -6,19 +6,26 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ongil.backend.domain.user.dto.request.BodyInfoRequest;
 import com.ongil.backend.domain.user.dto.request.UserUpdateProfileRequest;
-
+import com.ongil.backend.domain.user.dto.response.BodyInfoResponse;
+import com.ongil.backend.domain.user.dto.response.SizeOptionsResponse;
+import com.ongil.backend.domain.user.dto.response.TermsResponse;
 import com.ongil.backend.domain.user.dto.response.UserInfoResDto;
 import com.ongil.backend.domain.user.service.UserService;
 import com.ongil.backend.global.common.dto.DataResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "User", description = "회원 API")
 @Validated
 @RestController
 @RequiredArgsConstructor
@@ -52,6 +59,39 @@ public class UserController {
 		@RequestBody UserUpdateProfileRequest request
 	) {
 		UserInfoResDto res = userService.updateProfileImage(userId, request.profileImageUrl());
+		return ResponseEntity.ok(DataResponse.from(res));
+	}
+
+	@GetMapping("/me/body-info")
+	@Operation(summary = "체형 정보 조회 API", description = "로그인한 회원의 체형 정보를 조회합니다. 5개 항목 중 하나라도 없으면 hasBodyInfo=false (토큰 필요)")
+	public ResponseEntity<DataResponse<BodyInfoResponse>> getBodyInfo(
+		@AuthenticationPrincipal Long userId
+	) {
+		BodyInfoResponse res = userService.getBodyInfo(userId);
+		return ResponseEntity.ok(DataResponse.from(res));
+	}
+
+	@PutMapping("/me/body-info")
+	@Operation(summary = "체형 정보 저장/수정 API", description = "로그인한 회원의 체형 정보를 저장하거나 수정합니다. 모든 항목 필수입니다. (토큰 필요)")
+	public ResponseEntity<DataResponse<BodyInfoResponse>> updateBodyInfo(
+		@AuthenticationPrincipal Long userId,
+		@Valid @RequestBody BodyInfoRequest request
+	) {
+		BodyInfoResponse res = userService.updateBodyInfo(userId, request);
+		return ResponseEntity.ok(DataResponse.from(res));
+	}
+
+	@GetMapping("/body-info/size-options")
+	@Operation(summary = "사이즈 옵션 목록 조회 API", description = "드롭다운에 표시할 사이즈 옵션 목록을 조회합니다.")
+	public ResponseEntity<DataResponse<SizeOptionsResponse>> getSizeOptions() {
+		SizeOptionsResponse res = userService.getSizeOptions();
+		return ResponseEntity.ok(DataResponse.from(res));
+	}
+
+	@GetMapping("/body-info/terms")
+	@Operation(summary = "수집·이용 동의 약관 조회 API", description = "사이즈 정보 수집 동의 약관을 조회합니다.")
+	public ResponseEntity<DataResponse<TermsResponse>> getBodyInfoTerms() {
+		TermsResponse res = userService.getBodyInfoTerms();
 		return ResponseEntity.ok(DataResponse.from(res));
 	}
 

--- a/src/main/java/com/ongil/backend/domain/user/converter/BodyInfoConverter.java
+++ b/src/main/java/com/ongil/backend/domain/user/converter/BodyInfoConverter.java
@@ -1,0 +1,46 @@
+package com.ongil.backend.domain.user.converter;
+
+import com.ongil.backend.domain.user.dto.response.BodyInfoResponse;
+import com.ongil.backend.domain.user.dto.response.SizeOptionsResponse;
+import com.ongil.backend.domain.user.entity.User;
+import com.ongil.backend.domain.user.enums.BottomSize;
+import com.ongil.backend.domain.user.enums.ShoeSize;
+import com.ongil.backend.domain.user.enums.TopSize;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class BodyInfoConverter {
+
+	/**
+	 * User 엔티티를 BodyInfoResponse로 변환
+	 * 5개 필드 중 하나라도 null이면 hasBodyInfo = false
+	 */
+	public static BodyInfoResponse toResponse(User user) {
+		boolean hasBodyInfo = user.getHeight() != null
+			&& user.getWeight() != null
+			&& user.getUsualTopSize() != null
+			&& user.getUsualBottomSize() != null
+			&& user.getUsualShoeSize() != null;
+
+		return BodyInfoResponse.builder()
+			.hasBodyInfo(hasBodyInfo)
+			.height(user.getHeight())
+			.weight(user.getWeight())
+			.topSize(user.getUsualTopSize())
+			.bottomSize(user.getUsualBottomSize())
+			.shoeSize(user.getUsualShoeSize())
+			.build();
+	}
+
+	/**
+	 * Enum에서 사이즈 옵션 목록 생성
+	 */
+	public static SizeOptionsResponse toSizeOptionsResponse() {
+		return SizeOptionsResponse.builder()
+			.topSizes(TopSize.getAllDisplayNames())
+			.bottomSizes(BottomSize.getAllDisplayNames())
+			.shoeSizes(ShoeSize.getAllDisplayNames())
+			.build();
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/user/converter/BodyInfoConverter.java
+++ b/src/main/java/com/ongil/backend/domain/user/converter/BodyInfoConverter.java
@@ -14,14 +14,15 @@ public class BodyInfoConverter {
 
 	/**
 	 * User 엔티티를 BodyInfoResponse로 변환
-	 * 5개 필드 중 하나라도 null이면 hasBodyInfo = false
+	 * 5개 필드 중 하나라도 null이거나 동의하지 않은 경우 hasBodyInfo = false
 	 */
 	public static BodyInfoResponse toResponse(User user) {
 		boolean hasBodyInfo = user.getHeight() != null
 			&& user.getWeight() != null
 			&& user.getUsualTopSize() != null
 			&& user.getUsualBottomSize() != null
-			&& user.getUsualShoeSize() != null;
+			&& user.getUsualShoeSize() != null
+			&& Boolean.TRUE.equals(user.getBodyInfoAgreed());
 
 		return BodyInfoResponse.builder()
 			.hasBodyInfo(hasBodyInfo)

--- a/src/main/java/com/ongil/backend/domain/user/dto/request/BodyInfoRequest.java
+++ b/src/main/java/com/ongil/backend/domain/user/dto/request/BodyInfoRequest.java
@@ -1,0 +1,42 @@
+package com.ongil.backend.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "체형 정보 저장 요청")
+public record BodyInfoRequest(
+
+	@NotNull(message = "키를 입력해주세요.")
+	@Min(value = 100, message = "키는 100cm 이상이어야 합니다.")
+	@Max(value = 250, message = "키는 250cm 이하여야 합니다.")
+	@Schema(description = "키 (cm)", example = "175")
+	Integer height,
+
+	@NotNull(message = "몸무게를 입력해주세요.")
+	@Min(value = 20, message = "몸무게는 20kg 이상이어야 합니다.")
+	@Max(value = 300, message = "몸무게는 300kg 이하여야 합니다.")
+	@Schema(description = "몸무게 (kg)", example = "70")
+	Integer weight,
+
+	@NotBlank(message = "상의 사이즈를 선택해주세요.")
+	@Schema(description = "상의 사이즈", example = "66")
+	String topSize,
+
+	@NotBlank(message = "하의 사이즈를 선택해주세요.")
+	@Schema(description = "하의 사이즈", example = "30")
+	String bottomSize,
+
+	@NotBlank(message = "신발 사이즈를 선택해주세요.")
+	@Schema(description = "신발 사이즈", example = "270")
+	String shoeSize,
+
+	@NotNull(message = "수집 동의 여부를 선택해주세요.")
+	@AssertTrue(message = "사이즈 정보 수집에 동의해야 합니다.")
+	@Schema(description = "수집 동의 여부", example = "true")
+	Boolean agreedToCollection
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/user/dto/response/BodyInfoResponse.java
+++ b/src/main/java/com/ongil/backend/domain/user/dto/response/BodyInfoResponse.java
@@ -1,0 +1,29 @@
+package com.ongil.backend.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "체형 정보 응답")
+public class BodyInfoResponse {
+
+	@Schema(description = "체형 정보 존재 여부", example = "true")
+	private boolean hasBodyInfo;
+
+	@Schema(description = "키 (cm)", example = "175")
+	private Integer height;
+
+	@Schema(description = "몸무게 (kg)", example = "70")
+	private Integer weight;
+
+	@Schema(description = "상의 사이즈", example = "66")
+	private String topSize;
+
+	@Schema(description = "하의 사이즈", example = "30")
+	private String bottomSize;
+
+	@Schema(description = "신발 사이즈", example = "270")
+	private String shoeSize;
+}

--- a/src/main/java/com/ongil/backend/domain/user/dto/response/SizeOptionsResponse.java
+++ b/src/main/java/com/ongil/backend/domain/user/dto/response/SizeOptionsResponse.java
@@ -1,0 +1,22 @@
+package com.ongil.backend.domain.user.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "사이즈 옵션 목록 응답")
+public class SizeOptionsResponse {
+
+	@Schema(description = "상의 사이즈 목록")
+	private List<String> topSizes;
+
+	@Schema(description = "하의 사이즈 목록")
+	private List<String> bottomSizes;
+
+	@Schema(description = "신발 사이즈 목록")
+	private List<String> shoeSizes;
+}

--- a/src/main/java/com/ongil/backend/domain/user/dto/response/TermsResponse.java
+++ b/src/main/java/com/ongil/backend/domain/user/dto/response/TermsResponse.java
@@ -1,0 +1,23 @@
+package com.ongil.backend.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "약관 내용 응답")
+public class TermsResponse {
+
+	@Schema(description = "약관 제목")
+	private String title;
+
+	@Schema(description = "약관 내용")
+	private String content;
+
+	@Schema(description = "약관 버전")
+	private String version;
+
+	@Schema(description = "시행일")
+	private String effectiveDate;
+}

--- a/src/main/java/com/ongil/backend/domain/user/entity/User.java
+++ b/src/main/java/com/ongil/backend/domain/user/entity/User.java
@@ -67,7 +67,7 @@ public class User extends BaseEntity {
 	@Column(name = "usual_shoe_size", length = 10)
 	private String usualShoeSize;
 
-	@Column(name = "body_info_agreed")
+	@Column(name = "body_info_agreed", nullable = false)
 	@Builder.Default
 	private Boolean bodyInfoAgreed = false;
 

--- a/src/main/java/com/ongil/backend/domain/user/entity/User.java
+++ b/src/main/java/com/ongil/backend/domain/user/entity/User.java
@@ -67,6 +67,10 @@ public class User extends BaseEntity {
 	@Column(name = "usual_shoe_size", length = 10)
 	private String usualShoeSize;
 
+	@Column(name = "body_info_agreed")
+	@Builder.Default
+	private Boolean bodyInfoAgreed = false;
+
 	@Column(nullable = false)
 	@Builder.Default
 	private Integer points = 0;
@@ -78,5 +82,17 @@ public class User extends BaseEntity {
 	// 프로필 이미지 수정 비즈니스 로직
 	public void updateProfileImage(String newProfileImgUrl) {
 		this.profileImg = newProfileImgUrl;
+	}
+
+	// 체형 정보 수정 비즈니스 로직
+	public void updateBodyInfo(Integer height, Integer weight,
+							   String topSize, String bottomSize,
+							   String shoeSize, Boolean agreed) {
+		this.height = height;
+		this.weight = weight;
+		this.usualTopSize = topSize;
+		this.usualBottomSize = bottomSize;
+		this.usualShoeSize = shoeSize;
+		this.bodyInfoAgreed = agreed;
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/user/enums/BottomSize.java
+++ b/src/main/java/com/ongil/backend/domain/user/enums/BottomSize.java
@@ -1,0 +1,50 @@
+package com.ongil.backend.domain.user.enums;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ongil.backend.global.common.exception.AppException;
+import com.ongil.backend.global.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BottomSize {
+	SIZE_22_OR_LESS("22이하"),
+	SIZE_23("23"),
+	SIZE_24("24"),
+	SIZE_25("25"),
+	SIZE_26("26"),
+	SIZE_27("27"),
+	SIZE_28("28"),
+	SIZE_29("29"),
+	SIZE_30("30"),
+	SIZE_31("31"),
+	SIZE_32("32"),
+	SIZE_33("33"),
+	SIZE_34("34"),
+	SIZE_35("35"),
+	SIZE_36("36"),
+	SIZE_37("37"),
+	SIZE_38("38"),
+	SIZE_39("39"),
+	SIZE_40_OR_MORE("40이상");
+
+	private final String displayName;
+
+	public static BottomSize fromDisplayName(String displayName) {
+		return Arrays.stream(values())
+			.filter(size -> size.displayName.equals(displayName))
+			.findFirst()
+			.orElseThrow(() -> new AppException(ErrorCode.INVALID_SIZE));
+	}
+
+	public static List<String> getAllDisplayNames() {
+		return Arrays.stream(values())
+			.map(BottomSize::getDisplayName)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/user/enums/ShoeSize.java
+++ b/src/main/java/com/ongil/backend/domain/user/enums/ShoeSize.java
@@ -1,0 +1,46 @@
+package com.ongil.backend.domain.user.enums;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ongil.backend.global.common.exception.AppException;
+import com.ongil.backend.global.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ShoeSize {
+	SIZE_210_OR_LESS("210이하"),
+	SIZE_215("215"),
+	SIZE_220("220"),
+	SIZE_225("225"),
+	SIZE_230("230"),
+	SIZE_235("235"),
+	SIZE_240("240"),
+	SIZE_245("245"),
+	SIZE_250("250"),
+	SIZE_255("255"),
+	SIZE_260("260"),
+	SIZE_265("265"),
+	SIZE_270("270"),
+	SIZE_275("275"),
+	SIZE_280_OR_MORE("280이상");
+
+	private final String displayName;
+
+	public static ShoeSize fromDisplayName(String displayName) {
+		return Arrays.stream(values())
+			.filter(size -> size.displayName.equals(displayName))
+			.findFirst()
+			.orElseThrow(() -> new AppException(ErrorCode.INVALID_SIZE));
+	}
+
+	public static List<String> getAllDisplayNames() {
+		return Arrays.stream(values())
+			.map(ShoeSize::getDisplayName)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/user/enums/TopSize.java
+++ b/src/main/java/com/ongil/backend/domain/user/enums/TopSize.java
@@ -1,0 +1,37 @@
+package com.ongil.backend.domain.user.enums;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ongil.backend.global.common.exception.AppException;
+import com.ongil.backend.global.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TopSize {
+	SIZE_44_OR_LESS("44이하"),
+	SIZE_55("55"),
+	SIZE_66("66"),
+	SIZE_77("77"),
+	SIZE_88("88"),
+	SIZE_99_OR_MORE("99이상");
+
+	private final String displayName;
+
+	public static TopSize fromDisplayName(String displayName) {
+		return Arrays.stream(values())
+			.filter(size -> size.displayName.equals(displayName))
+			.findFirst()
+			.orElseThrow(() -> new AppException(ErrorCode.INVALID_SIZE));
+	}
+
+	public static List<String> getAllDisplayNames() {
+		return Arrays.stream(values())
+			.map(TopSize::getDisplayName)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/ongil/backend/domain/user/service/UserService.java
@@ -3,9 +3,17 @@ package com.ongil.backend.domain.user.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ongil.backend.domain.user.converter.BodyInfoConverter;
 import com.ongil.backend.domain.user.converter.UserConverter;
+import com.ongil.backend.domain.user.dto.request.BodyInfoRequest;
+import com.ongil.backend.domain.user.dto.response.BodyInfoResponse;
+import com.ongil.backend.domain.user.dto.response.SizeOptionsResponse;
+import com.ongil.backend.domain.user.dto.response.TermsResponse;
 import com.ongil.backend.domain.user.dto.response.UserInfoResDto;
 import com.ongil.backend.domain.user.entity.User;
+import com.ongil.backend.domain.user.enums.BottomSize;
+import com.ongil.backend.domain.user.enums.ShoeSize;
+import com.ongil.backend.domain.user.enums.TopSize;
 import com.ongil.backend.domain.user.repository.UserRepository;
 import com.ongil.backend.global.common.exception.EntityNotFoundException;
 import com.ongil.backend.global.common.exception.ErrorCode;
@@ -39,5 +47,57 @@ public class UserService {
 	private User findUser(Long userId) {
 		return userRepository.findById(userId)
 				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+	}
+
+	// 3. 체형 정보 조회
+	public BodyInfoResponse getBodyInfo(Long userId) {
+		User user = findUser(userId);
+		return BodyInfoConverter.toResponse(user);
+	}
+
+	// 4. 체형 정보 저장/수정
+	@Transactional
+	public BodyInfoResponse updateBodyInfo(Long userId, BodyInfoRequest request) {
+		User user = findUser(userId);
+
+		// Enum 유효성 검증 (잘못된 값이면 예외 발생)
+		TopSize.fromDisplayName(request.topSize());
+		BottomSize.fromDisplayName(request.bottomSize());
+		ShoeSize.fromDisplayName(request.shoeSize());
+
+		// 체형 정보 업데이트
+		user.updateBodyInfo(
+			request.height(),
+			request.weight(),
+			request.topSize(),
+			request.bottomSize(),
+			request.shoeSize(),
+			request.agreedToCollection()
+		);
+
+		return BodyInfoConverter.toResponse(user);
+	}
+
+	// 5. 사이즈 옵션 목록 조회
+	public SizeOptionsResponse getSizeOptions() {
+		return BodyInfoConverter.toSizeOptionsResponse();
+	}
+
+	// 6. 수집·이용 동의 약관 조회
+	public TermsResponse getBodyInfoTerms() {
+		return TermsResponse.builder()
+			.title("사이즈 정보 수집·이용 동의")
+			.content("1. 수집 항목\n" +
+				"- 키, 몸무게, 상의 사이즈, 하의 사이즈, 신발 사이즈\n\n" +
+				"2. 수집 목적\n" +
+				"- 맞춤형 사이즈 추천 서비스 제공\n" +
+				"- 리뷰 작성 시 체형 정보 자동 입력\n\n" +
+				"3. 보유 기간\n" +
+				"- 회원 탈퇴 시까지\n\n" +
+				"4. 동의 거부권 및 불이익\n" +
+				"- 동의를 거부할 권리가 있으며, 거부 시 맞춤 사이즈 추천 서비스 이용이 제한됩니다.")
+			.version("1.0")
+			.effectiveDate("2026-01-01")
+			.build();
 	}
 }

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 
 	// USER
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.", "USER-001"),
+	INVALID_SIZE(HttpStatus.BAD_REQUEST, "유효하지 않은 사이즈입니다.", "USER-002"),
 
 	// PRODUCT
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다.", "PRODUCT-001"),

--- a/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
@@ -72,7 +72,8 @@ public class SecurityConfig {
 				.requestMatchers("/api/carts/**").authenticated()
 				.requestMatchers("/api/wishlists/**").authenticated()
 
-				// [10] 사용자 관련 - 전체 인증 필요
+				// [10] 사용자 관련
+				.requestMatchers(HttpMethod.GET, "/api/users/body-info/**").permitAll()  // 사이즈 옵션, 약관 조회는 인증 불필요
 				.requestMatchers("/api/users/me/**").authenticated()
 				.requestMatchers("/api/users/**").authenticated()
 


### PR DESCRIPTION

## 🔍️ 작업 내용
* Closes #
- 체형 정보 조회 API (GET /api/users/me/body-info)
- 체형 정보 저장/수정 API (PUT /api/users/me/body-info)
- 사이즈 옵션 목록 조회 API (GET /api/users/body-info/size-options)
- 수집·이용 동의 약관 조회 API (GET /api/users/body-info/terms)
- TopSize, BottomSize, ShoeSize Enum 추가
- User 엔티티에 bodyInfoAgreed 필드 및 updateBodyInfo 메서드 추가

## ✨ 상세 설명

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 키/체중 및 의류(상의·하의·신발) 정보 조회·저장 기능 추가 (동의 검증 포함).
  * 사이즈 옵션 목록 및 수집·이용 약관 조회 기능 추가.

* **Bug Fixes**
  * 요청 유효성 검증을 강화하여 잘못된 입력 처리 개선.

* **Chores**
  * 일부 API 경로의 접근 권한 예외 설정을 조정하여 공개 조회를 허용함.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->