### PR TITLE
[Feat] 매거진 크롤링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 
     // Elasticsearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
+    // Crawling
+    implementation 'org.jsoup:jsoup:1.17.2'
 }
 
 dependencyManagement {

--- a/src/main/java/com/ongil/backend/Application.java
+++ b/src/main/java/com/ongil/backend/Application.java
@@ -8,14 +8,15 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableFeignClients
 @EnableAsync
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+@EnableScheduling
 public class Application {
-
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}

--- a/src/main/java/com/ongil/backend/domain/magazine/controller/MagazineController.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/controller/MagazineController.java
@@ -1,0 +1,120 @@
+package com.ongil.backend.domain.magazine.controller;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ongil.backend.domain.magazine.dto.request.CommentReqDto;
+import com.ongil.backend.domain.magazine.dto.response.CommentResDto;
+import com.ongil.backend.domain.magazine.dto.response.MagazineResDto;
+import com.ongil.backend.domain.magazine.enums.MagazineCategory;
+import com.ongil.backend.domain.magazine.service.MagazineCommentService;
+import com.ongil.backend.domain.magazine.service.MagazineCrawlingService;
+import com.ongil.backend.domain.magazine.service.MagazineService;
+import com.ongil.backend.global.common.dto.DataResponse;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/magazines")
+@RequiredArgsConstructor
+@Tag(name = "Magazine", description = "매거진 API")
+public class MagazineController {
+
+	private final MagazineService magazineService;
+	private final MagazineCommentService commentService;
+	private final MagazineCrawlingService crawlingService;
+
+	@GetMapping("/recommend")
+	@Operation(summary = "추천 매거진 조회", description = "임의 매거진 6개를 반환합니다.")
+	public DataResponse<List<MagazineResDto>> getRecommended() {
+		List<MagazineResDto> response = magazineService.getRecommendedMagazines();
+		return DataResponse.from(response);
+	}
+
+	@GetMapping
+	@Operation(summary = "주제별 매거진 조회", description = "주제별 매거진을 조회합니다. 기본값은 가격")
+	public DataResponse<List<MagazineResDto>> getByCategory(
+		@RequestParam(required = false, defaultValue = "PRICE") MagazineCategory category) {
+		List<MagazineResDto> response = magazineService.getMagazinesByCategory(category);
+		return DataResponse.from(response);
+	}
+
+	@GetMapping("/{magazineId}")
+	@Operation(summary = "매거진 상세 조회", description = "특정 ID의 매거진 상세 내용을 조회하고 조회수를 1 증가시킵니다.")
+	public DataResponse<MagazineResDto> getMagazineDetail(@PathVariable Long magazineId) {
+		MagazineResDto response = magazineService.getMagazineDetail(magazineId);
+		return DataResponse.from(response);
+	}
+
+	@PostMapping("/{magazineId}/bookmark")
+	@Operation(summary = "매거진 저장 토글", description = "해당 매거진을 저장하거나 저장 취소 합니다. true: 저장 성공 의미(토큰 필요)")
+	public DataResponse<Boolean> toggleBookmark(
+		@PathVariable Long magazineId, @AuthenticationPrincipal Long userId ) {
+		boolean isBookmarked = magazineService.toggleBookmark(magazineId, userId);
+		return DataResponse.from(isBookmarked);
+	}
+
+	@GetMapping("/bookmarks")
+	@Operation(summary = "저장된 매거진 목록 조회", description = "카테고리 필터가 가능하며 기본값은 가격 카테고리입니다. (토큰 필요)")
+	public DataResponse<List<MagazineResDto>> getBookmarkedMagazines(
+		@AuthenticationPrincipal Long userId,
+		@RequestParam(required = false) MagazineCategory category) {
+		List<MagazineResDto> response = magazineService.getBookmarkedMagazines(userId, category);
+		return DataResponse.from(response);
+	}
+
+	@PostMapping("/comments/{magazineId}")
+	@Operation(summary = "댓글 등록", description = "특정 매거진에 댓글을 등록하고 작성된 댓글 정보를 반환합니다. (토큰필요)")
+	public DataResponse<CommentResDto> createComment(
+		@PathVariable Long magazineId, @AuthenticationPrincipal Long userId, @RequestBody CommentReqDto request) {
+		CommentResDto response = commentService.createComment(magazineId, userId, request.content());
+		return DataResponse.from(response);
+	}
+
+	@GetMapping("/comments/{magazineId}")
+	@Operation(summary = "댓글 조회", description = "특정 매거진의 댓글을 조회합니다.")
+	public DataResponse<List<CommentResDto>> getComments(
+		@PathVariable Long magazineId) {
+		List<CommentResDto> response = commentService.getComments(magazineId);
+		return DataResponse.from(response);
+	}
+
+	@PostMapping("/{commentId}/like")
+	@Operation(summary = "댓글 공감 토글", description = "도움 됐어요 기능을 토글합니다. true: 공감 성공 의미 (토큰 필요)")
+	public DataResponse<Boolean> toggleLike(
+		@PathVariable Long commentId,
+		@AuthenticationPrincipal Long userId) {
+		boolean isLiked = commentService.toggleCommentLike(commentId, userId);
+		return DataResponse.from(isLiked);
+	}
+
+	@Hidden
+	@PostMapping("/crawl")
+	@Operation(summary = "매거진 수동 크롤링", description = "매거진 데이터가 부족할 경우를 위한 api")
+	public DataResponse<String> manualCrawl(@RequestParam(required = false) MagazineCategory category) {
+		CompletableFuture.runAsync(() -> {
+			if (category != null) {
+				crawlingService.crawlAndSave(category);
+			} else {
+				// 카테고리 미지정 시 전체 크롤링
+				for (MagazineCategory cat : MagazineCategory.values()) {
+					crawlingService.crawlAndSave(cat);
+				}
+			}
+		});
+
+		return DataResponse.from("수동 크롤링 시작");
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/converter/CommentConverter.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/converter/CommentConverter.java
@@ -1,0 +1,21 @@
+package com.ongil.backend.domain.magazine.converter;
+
+import com.ongil.backend.domain.magazine.dto.response.CommentResDto;
+import com.ongil.backend.domain.magazine.entity.MagazineComment;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class CommentConverter {
+	public static CommentResDto from(MagazineComment comment) {
+		return CommentResDto.builder()
+			.commentId(comment.getId())
+			.userId(comment.getUser().getId())
+			.userName(comment.getUser().getName())
+			.userProfileImage(comment.getUser().getProfileImg())
+			.content(comment.getContent())
+			.likeCount(comment.getLikeCount())
+			.createdAt(comment.getCreatedAt().toString())
+			.build();
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/converter/MagazineConverter.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/converter/MagazineConverter.java
@@ -1,0 +1,22 @@
+package com.ongil.backend.domain.magazine.converter;
+
+import com.ongil.backend.domain.magazine.dto.response.MagazineResDto;
+import com.ongil.backend.domain.magazine.entity.Magazine;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class MagazineConverter {
+	public static MagazineResDto from(Magazine magazine) {
+		return MagazineResDto.builder()
+			.id(magazine.getId())
+			.title(magazine.getTitle())
+			.content(magazine.getContent())
+			.category(magazine.getCategory().name())
+			.thumbnailUrl(magazine.getThumbnailImageUrl())
+			.originalUrl(magazine.getUrl())
+			.press(magazine.getPress())
+			.publishedAt(magazine.getPublishedAt().toString())
+			.build();
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/converter/MagazineConverter.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/converter/MagazineConverter.java
@@ -16,7 +16,7 @@ public class MagazineConverter {
 			.thumbnailUrl(magazine.getThumbnailImageUrl())
 			.originalUrl(magazine.getUrl())
 			.press(magazine.getPress())
-			.publishedAt(magazine.getPublishedAt().toString())
+			.publishedAt(magazine.getPublishedAt() != null ? magazine.getPublishedAt().toString() : "")
 			.build();
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/magazine/dto/request/CommentReqDto.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/dto/request/CommentReqDto.java
@@ -1,0 +1,10 @@
+package com.ongil.backend.domain.magazine.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentReqDto(
+	@NotBlank(message = "댓글 내용은 비어있을 수 없습니다.")
+	@Size(max = 500, message = "댓글은 최대 500자까지 입력 가능합니다.")
+	String content
+) {}

--- a/src/main/java/com/ongil/backend/domain/magazine/dto/response/CommentResDto.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/dto/response/CommentResDto.java
@@ -1,0 +1,15 @@
+package com.ongil.backend.domain.magazine.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentResDto(
+	Long commentId,
+	Long userId,
+	String userName,
+	String userProfileImage,
+	String content,
+	Integer likeCount,
+	String createdAt
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/dto/response/MagazineResDto.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/dto/response/MagazineResDto.java
@@ -1,0 +1,39 @@
+package com.ongil.backend.domain.magazine.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import jakarta.validation.constraints.NotNull;
+
+@Builder
+@Schema(description = "매거진 응답 DTO")
+public record MagazineResDto(
+
+	@Schema(description = "매거진 ID")
+	@NotNull
+	Long id,
+
+	@Schema(description = "매거진 제목")
+	@NotNull
+	String title,
+
+	@Schema(description = "매거진 내용")
+	String content,
+
+	@Schema(description = "카테고리 (가격, 체형, 소재, 색상)")
+	@NotNull
+	String category,
+
+	@Schema(description = "썸네일 이미지 URL")
+	String thumbnailUrl,
+
+	@Schema(description = "원문 뉴스 URL")
+	@NotNull
+	String originalUrl,
+
+	@Schema(description = "언론사명")
+	String press,
+
+	@Schema(description = "발행 시간")
+	String publishedAt
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/entity/Magazine.java
@@ -1,5 +1,6 @@
 package com.ongil.backend.domain.magazine.entity;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import com.ongil.backend.domain.magazine.enums.*;
@@ -10,9 +11,16 @@ import jakarta.persistence.Table;
 import lombok.*;
 
 @Entity
-@Table(name = "magazines")
+@Table(
+	name = "magazines",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_magazine_url", columnNames = "url")
+	}
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@AllArgsConstructor
+@Builder
 public class Magazine extends BaseEntity {
 
 	@Id
@@ -26,11 +34,15 @@ public class Magazine extends BaseEntity {
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
+	@Column(unique = true)
+	private String url;
+
+	private LocalDateTime publishedAt;
+
+	private String press;
+
 	@Column(name = "thumbnail_image_url", length = 500)
 	private String thumbnailImageUrl;
-
-	@Column(name = "magazine_image_urls", columnDefinition = "TEXT")
-	private String magazineImageUrls;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -45,14 +57,7 @@ public class Magazine extends BaseEntity {
 	@OneToMany(mappedBy = "magazine")
 	private List<MagazineComment> comments = new ArrayList<>();
 
-	@Builder
-	public Magazine(String title, String content, String thumbnailImageUrl,
-		String magazineImageUrls, MagazineCategory category, String authorName) {
-		this.title = title;
-		this.content = content;
-		this.thumbnailImageUrl = thumbnailImageUrl;
-		this.magazineImageUrls = magazineImageUrls;
-		this.category = category;
-		this.authorName = authorName;
+	public void addViewCount() {
+		this.viewCount++;
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/magazine/entity/MagazineBookmark.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/entity/MagazineBookmark.java
@@ -1,0 +1,30 @@
+package com.ongil.backend.domain.magazine.entity;
+
+import com.ongil.backend.domain.user.entity.User;
+import com.ongil.backend.global.common.entity.BaseEntity;
+
+import jakarta.persistence.*;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "magazine_bookmarks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MagazineBookmark extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "magazine_bookmark_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "magazine_id")
+	private Magazine magazine;
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/entity/MagazineBookmark.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/entity/MagazineBookmark.java
@@ -8,7 +8,15 @@ import jakarta.persistence.Table;
 import lombok.*;
 
 @Entity
-@Table(name = "magazine_bookmarks")
+@Table(
+	name = "magazine_bookmarks",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_magazine_bookmark_user_magazine",
+			columnNames = {"user_id", "magazine_id"}
+		)
+	}
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/ongil/backend/domain/magazine/entity/MagazineComment.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/entity/MagazineComment.java
@@ -5,6 +5,7 @@ import com.ongil.backend.global.common.entity.BaseEntity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +14,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "magazine_comments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Builder
+@AllArgsConstructor
 public class MagazineComment extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "magazine_comment_id")
 	private Long id;
 
 	@Column(nullable = false, length = 500)
@@ -30,11 +34,11 @@ public class MagazineComment extends BaseEntity {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@Builder
-	public MagazineComment(String content, Magazine magazine, User user) {
-		this.content = content;
-		this.magazine = magazine;
-		this.user = user;
-	}
+	@Builder.Default
+	@Column(name = "like_count", nullable = false)
+	private Integer likeCount = 0;
+
+	public void increaseLikeCount() { this.likeCount++; }
+	public void decreaseLikeCount() { if(this.likeCount > 0) this.likeCount--; }
 }
 

--- a/src/main/java/com/ongil/backend/domain/magazine/entity/MagazineCommentLike.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/entity/MagazineCommentLike.java
@@ -1,0 +1,38 @@
+package com.ongil.backend.domain.magazine.entity;
+
+import com.ongil.backend.domain.user.entity.User;
+import com.ongil.backend.global.common.entity.BaseEntity;
+
+import jakarta.persistence.*;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(
+	name = "magazine_comment_likes",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_comment_user_like",
+			columnNames = {"magazine_comment_id", "user_id"}
+		)
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MagazineCommentLike extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "magazine_comment_like_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "magazine_comment_id")
+	private MagazineComment comment;
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/parser/MagazineArticleParser.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/parser/MagazineArticleParser.java
@@ -1,0 +1,10 @@
+package com.ongil.backend.domain.magazine.parser;
+
+import java.util.Optional;
+
+import com.ongil.backend.domain.magazine.entity.Magazine;
+import com.ongil.backend.domain.magazine.enums.MagazineCategory;
+
+public interface MagazineArticleParser {
+	Optional<Magazine> parse(String url, MagazineCategory category);
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/parser/NaverNewsParser.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/parser/NaverNewsParser.java
@@ -1,0 +1,119 @@
+package com.ongil.backend.domain.magazine.parser;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import com.ongil.backend.domain.magazine.entity.Magazine;
+import com.ongil.backend.domain.magazine.enums.MagazineCategory;
+
+@Component
+@Slf4j
+public class NaverNewsParser implements MagazineArticleParser {
+
+	@Override
+	public Optional<Magazine> parse(String url, MagazineCategory category) {
+		try {
+			Thread.sleep(800 + (long)(Math.random() * 500)); // 랜덤 지연
+
+			Document doc = Jsoup.connect(url)
+				.userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+				.timeout(10000)
+				.get();
+
+			String title = extractTitle(doc);
+			String content = extractContent(doc);
+
+			if (title.isEmpty() || content.isEmpty()) {
+				log.warn("제목이나 본문이 비어있음: {}", url);
+				return Optional.empty();
+			}
+
+			return Optional.of(
+				Magazine.builder()
+					.title(title)
+					.content(content)
+					.url(url)
+					.category(category)
+					.press(extractPress(doc))
+					.thumbnailImageUrl(extractThumbnail(doc))
+					.authorName(extractAuthor(doc))
+					.publishedAt(extractPublishedAt(doc))
+					.viewCount(0)
+					.build()
+			);
+		} catch (Exception e) {
+			log.warn("기사 파싱 실패: {}", url, e);
+			return Optional.empty();
+		}
+	}
+
+	private String extractThumbnail(Document doc) {
+		Element metaOgImage = doc.selectFirst("meta[property=og:image]");
+		return metaOgImage != null ? metaOgImage.attr("content") : null;
+	}
+
+	private String extractPress(Document doc) {
+		Element pressEl = doc.selectFirst(".media_end_head_top_logo img");
+		if (pressEl != null) return pressEl.attr("alt");
+
+		Element pressTextEl = doc.selectFirst(".media_end_head_top_channel_layer_text");
+		return pressTextEl != null ? pressTextEl.text().trim() : "알 수 없음";
+	}
+
+	private String extractAuthor(Document doc) {
+		Element authorEl = doc.selectFirst(".byline_s, .media_end_head_journalist_name");
+		if (authorEl != null) {
+			return authorEl.text().trim();
+		}
+		return null;
+	}
+
+	private String extractTitle(Document doc) {
+		Element titleEl = doc.selectFirst("#title_area, h2.media_end_head_headline, #articleTitle");
+		return titleEl != null ? titleEl.text().trim() : "";
+	}
+
+	private String extractContent(Document doc) {
+		Element body = doc.selectFirst("#newsct_article, #dic_area, #articleBodyContents");
+
+		if (body != null) {
+			body.select("script, style, .end_photo_org, .article_footer, .reporter_area, .copyright").remove();
+			return body.text().trim();
+		}
+		return "";
+	}
+
+	private static final DateTimeFormatter NAVER_DATE_FORMATTER =
+		DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+	private LocalDateTime extractPublishedAt(Document doc) {
+		try {
+			Element time = doc.selectFirst("span[data-date-time]");
+			if (time != null) {
+				String dateStr = time.attr("data-date-time"); // "2026-01-30 11:39:40"
+				return LocalDateTime.parse(dateStr, NAVER_DATE_FORMATTER);
+			}
+
+			Element meta = doc.selectFirst("meta[property=article:published_time]");
+			if (meta != null) {
+				String content = meta.attr("content");
+				return LocalDateTime.parse(content.replace(" ", "T"),
+					DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+			}
+		} catch (Exception e) {
+			log.warn("날짜 파싱 중 오류 발생, 현재 시간으로 대체합니다.");
+		}
+		return LocalDateTime.now();
+	}
+
+
+}
+

--- a/src/main/java/com/ongil/backend/domain/magazine/repository/CommentLikeRepository.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/repository/CommentLikeRepository.java
@@ -1,0 +1,15 @@
+package com.ongil.backend.domain.magazine.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ongil.backend.domain.magazine.entity.MagazineComment;
+import com.ongil.backend.domain.magazine.entity.MagazineCommentLike;
+import com.ongil.backend.domain.user.entity.User;
+
+@Repository
+public interface CommentLikeRepository extends JpaRepository<MagazineCommentLike, Long> {
+	Optional<MagazineCommentLike> findByCommentAndUser(MagazineComment comment, User user);
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/repository/MagazineBookmarkRepository.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/repository/MagazineBookmarkRepository.java
@@ -1,0 +1,29 @@
+package com.ongil.backend.domain.magazine.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.ongil.backend.domain.magazine.entity.Magazine;
+import com.ongil.backend.domain.magazine.entity.MagazineBookmark;
+import com.ongil.backend.domain.magazine.enums.MagazineCategory;
+import com.ongil.backend.domain.user.entity.User;
+
+@Repository
+public interface MagazineBookmarkRepository extends JpaRepository<MagazineBookmark, Long> {
+	Optional<MagazineBookmark> findByUserAndMagazine(User user, Magazine magazine);
+
+	List<MagazineBookmark> findByUserOrderByCreatedAtDesc(User user);
+
+	@Query("SELECT mb FROM MagazineBookmark mb JOIN mb.magazine m " +
+		"WHERE mb.user = :user AND m.category = :category " +
+		"ORDER BY mb.createdAt DESC")
+	List<MagazineBookmark> findByUserAndMagazineCategoryOrderByCreatedAtDesc(
+		@Param("user") User user,
+		@Param("category") MagazineCategory category
+	);
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/repository/MagazineCommentRepository.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/repository/MagazineCommentRepository.java
@@ -1,8 +1,20 @@
 package com.ongil.backend.domain.magazine.repository;
 
+import java.util.List;
+import org.springframework.data.repository.query.Param;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import com.ongil.backend.domain.magazine.entity.MagazineComment;
 
+@Repository
 public interface MagazineCommentRepository extends JpaRepository<MagazineComment, Long> {
+
+
+	@Query("SELECT mc FROM MagazineComment mc JOIN FETCH mc.user " +
+		"WHERE mc.magazine.id = :magazineId " +
+		"ORDER BY mc.createdAt DESC")
+	List<MagazineComment> findByMagazineIdOrderByCreatedAtDesc(@Param("magazineId") Long magazineId);
 }

--- a/src/main/java/com/ongil/backend/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/repository/MagazineRepository.java
@@ -1,8 +1,25 @@
 package com.ongil.backend.domain.magazine.repository;
 
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import com.ongil.backend.domain.magazine.entity.Magazine;
+import com.ongil.backend.domain.magazine.enums.MagazineCategory;
 
+@Repository
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+
+	@Query(value = "SELECT * FROM magazines ORDER BY RAND()", nativeQuery = true)
+	List<Magazine> findRandomRecommended(Pageable pageable);
+
+	List<Magazine> findByCategoryOrderByViewCountDescPublishedAtDesc(MagazineCategory category, Pageable pageable);
+
+	@Query("select m.url from Magazine m where m.url in :urls")
+	Set<String> findAllUrlsByUrlIn(@Param("urls") List<String> urls);
 }

--- a/src/main/java/com/ongil/backend/domain/magazine/scheduler/MagazineScheduler.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/scheduler/MagazineScheduler.java
@@ -1,0 +1,38 @@
+package com.ongil.backend.domain.magazine.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.ongil.backend.domain.magazine.enums.MagazineCategory;
+import com.ongil.backend.domain.magazine.service.MagazineCrawlingService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MagazineScheduler {
+
+	private final MagazineCrawlingService magazineCrawlingService;
+
+	/**
+	 * 매주 월요일 새벽 3시
+	 */
+	@Scheduled(cron = "0 0 3 ? * MON")
+	public void weeklyCrawlMagazines() {
+		log.info("매거진 주간 크롤링 시작");
+		crawlAll();
+		log.info("매거진 주간 크롤링 완료");
+	}
+
+	private void crawlAll() {
+		for (MagazineCategory category : MagazineCategory.values()) {
+			try {
+				magazineCrawlingService.crawlAndSave(category);
+			} catch (Exception e) {
+				log.error("카테고리 크롤링 실패: {}", category, e);
+			}
+		}
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/service/MagazineCommentService.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/service/MagazineCommentService.java
@@ -1,0 +1,86 @@
+package com.ongil.backend.domain.magazine.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.ongil.backend.domain.magazine.converter.CommentConverter;
+import com.ongil.backend.domain.magazine.dto.response.CommentResDto;
+import com.ongil.backend.domain.magazine.entity.Magazine;
+import com.ongil.backend.domain.magazine.entity.MagazineComment;
+import com.ongil.backend.domain.magazine.entity.MagazineCommentLike;
+import com.ongil.backend.domain.magazine.repository.CommentLikeRepository;
+import com.ongil.backend.domain.magazine.repository.MagazineCommentRepository;
+import com.ongil.backend.domain.magazine.repository.MagazineRepository;
+import com.ongil.backend.domain.user.entity.User;
+import com.ongil.backend.domain.user.repository.UserRepository;
+import com.ongil.backend.global.common.exception.EntityNotFoundException;
+import com.ongil.backend.global.common.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MagazineCommentService {
+
+	private final MagazineCommentRepository commentRepository;
+	private final MagazineRepository magazineRepository;
+	private final UserRepository userRepository;
+	private final CommentLikeRepository commentLikeRepository;
+
+	@Transactional
+	public CommentResDto createComment(Long magazineId, Long userId, String content) {
+		Magazine magazine = magazineRepository.findById(magazineId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MAGAZINE_NOT_FOUND));
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		MagazineComment comment = MagazineComment.builder()
+			.content(content)
+			.user(user)
+			.magazine(magazine)
+			.likeCount(0)
+			.build();
+
+		MagazineComment savedComment = commentRepository.save(comment);
+
+		return CommentConverter.from(savedComment);
+	}
+
+	public List<CommentResDto> getComments(Long magazineId) {
+		return commentRepository.findByMagazineIdOrderByCreatedAtDesc(magazineId)
+			.stream()
+			.map(CommentConverter::from)
+			.toList();
+	}
+
+	@Transactional
+	public boolean toggleCommentLike(Long commentId, Long userId) {
+		MagazineComment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		Optional<MagazineCommentLike> existingLike = commentLikeRepository.findByCommentAndUser(comment, user);
+
+		if (existingLike.isPresent()) {
+			commentLikeRepository.delete(existingLike.get());
+			comment.decreaseLikeCount();
+			return false;
+		} else {
+			MagazineCommentLike newLike = MagazineCommentLike.builder()
+				.comment(comment)
+				.user(user)
+				.build();
+			commentLikeRepository.save(newLike);
+			comment.increaseLikeCount();
+			return true;
+		}
+	}
+
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/service/MagazineCrawlingService.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/service/MagazineCrawlingService.java
@@ -1,0 +1,108 @@
+package com.ongil.backend.domain.magazine.service;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.ongil.backend.domain.magazine.entity.Magazine;
+import com.ongil.backend.domain.magazine.enums.MagazineCategory;
+import com.ongil.backend.domain.magazine.parser.MagazineArticleParser;
+import com.ongil.backend.domain.magazine.repository.MagazineRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MagazineCrawlingService {
+
+	private final MagazineRepository magazineRepository;
+	private final MagazineArticleParser articleParser;
+
+	private static final int MAX_PAGES = 3;
+	private static final String SEARCH_URL =
+		"https://search.naver.com/search.naver?where=news&query=%s&sort=0&start=%d";
+
+	public void crawlAndSave(MagazineCategory category) {
+		List<String> searchQueries = getSearchQueriesByCategory(category);
+		Set<String> visitedUrls = new HashSet<>();
+		List<Magazine> candidates = new ArrayList<>();
+
+		for (String searchQuery : searchQueries) {
+			log.info("=== 크롤링 시작 | 카테고리: {} | 검색어: {} ===", category, searchQuery);
+			for (int page = 1; page <= MAX_PAGES; page++) {
+
+				int start = 1 + (page - 1) * 10;
+				String url = String.format(
+					SEARCH_URL,
+					URLEncoder.encode(searchQuery, StandardCharsets.UTF_8),
+					start
+				);
+
+				try {
+					Document doc = Jsoup.connect(url)
+						.userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+						.timeout(10000)
+						.get();
+
+					List<String> articleLinks = extractArticleLinks(doc);
+
+					for (String articleUrl : articleLinks) {
+						if (!visitedUrls.add(articleUrl)) continue;
+
+						articleParser.parse(articleUrl, category)
+							.ifPresent(candidates::add);
+					}
+
+				} catch (IOException e) {
+					log.warn("검색어 [{}] 페이지 {} 크롤링 실패", searchQuery, page, e);
+				}
+			}
+		}
+
+		Set<String> existUrls = magazineRepository.findAllUrlsByUrlIn(
+			candidates.stream().map(Magazine::getUrl).toList()
+		);
+
+		List<Magazine> newMagazines = candidates.stream()
+			.filter(m -> !existUrls.contains(m.getUrl()))
+			.toList();
+
+		log.info("후보군 개수: {} | DB 중복 제외 후 신규 개수: {}", candidates.size(), newMagazines.size());
+		magazineRepository.saveAll(newMagazines);
+
+		log.info("=== 크롤링 종료 | 카테고리: {} | 저장 {}건 ===",
+			category, newMagazines.size());
+	}
+
+	private List<String> getSearchQueriesByCategory(MagazineCategory category) {
+		return switch (category) {
+			case BODY_TYPE -> List.of("체형별 코디", "체형 보완 스타일링", "체형별 패션 팁");
+			case COLOR -> List.of("2026 패션 컬러", "퍼스널컬러 코디", "트렌드 색상 스타일링");
+			case MATERIAL -> List.of("의류 소재 특징", "패션 원단 트렌드", "고급 소재 의류");
+			case PRICE -> List.of("가성비 패션", "아이템 세일", "세일 추천");
+		};
+	}
+
+	private List<String> extractArticleLinks(Document doc) {
+		return doc.select("a[href]")
+			.stream()
+			.map(e -> e.attr("abs:href"))
+			.filter(href -> href.contains("n.news.naver.com") && !href.contains("/comment/"))
+			.distinct()
+			.limit(20)
+			.toList();
+	}
+
+
+}

--- a/src/main/java/com/ongil/backend/domain/magazine/service/MagazineService.java
+++ b/src/main/java/com/ongil/backend/domain/magazine/service/MagazineService.java
@@ -1,0 +1,98 @@
+package com.ongil.backend.domain.magazine.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.PageRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.ongil.backend.domain.magazine.converter.MagazineConverter;
+import com.ongil.backend.domain.magazine.dto.response.MagazineResDto;
+import com.ongil.backend.domain.magazine.entity.Magazine;
+import com.ongil.backend.domain.magazine.entity.MagazineBookmark;
+import com.ongil.backend.domain.magazine.enums.MagazineCategory;
+import com.ongil.backend.domain.magazine.repository.MagazineBookmarkRepository;
+import com.ongil.backend.domain.magazine.repository.MagazineRepository;
+import com.ongil.backend.domain.user.entity.User;
+import com.ongil.backend.domain.user.repository.UserRepository;
+import com.ongil.backend.global.common.exception.AppException;
+import com.ongil.backend.global.common.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class MagazineService {
+
+	private final MagazineRepository magazineRepository;
+	private final MagazineBookmarkRepository bookmarkRepository;
+	private final UserRepository userRepository;
+
+	public List<MagazineResDto> getRecommendedMagazines() {
+		return magazineRepository.findRandomRecommended(PageRequest.of(0, 6))
+			.stream()
+			.map(MagazineConverter::from)
+			.toList();
+	}
+
+
+	public List<MagazineResDto> getMagazinesByCategory(MagazineCategory category) {
+		MagazineCategory targetCategory = (category != null) ? category : MagazineCategory.PRICE;
+
+		return magazineRepository.findByCategoryOrderByViewCountDescPublishedAtDesc(targetCategory, PageRequest.of(0, 15))
+			.stream()
+			.map(MagazineConverter::from)
+			.toList();
+	}
+
+	@Transactional
+	public MagazineResDto getMagazineDetail(Long magazineId) {
+		Magazine magazine = magazineRepository.findById(magazineId)
+			.orElseThrow(() -> new AppException(ErrorCode.MAGAZINE_NOT_FOUND));
+
+		magazine.addViewCount();
+
+		return MagazineConverter.from(magazine);
+	}
+
+	@Transactional
+	public boolean toggleBookmark(Long magazineId, Long userId) {
+		Magazine magazine = magazineRepository.findById(magazineId)
+			.orElseThrow(() -> new AppException(ErrorCode.MAGAZINE_NOT_FOUND));
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+
+		Optional<MagazineBookmark> bookmark = bookmarkRepository.findByUserAndMagazine(user, magazine);
+
+		if (bookmark.isPresent()) {
+			bookmarkRepository.delete(bookmark.get());
+			return false;
+		} else {
+			bookmarkRepository.save(MagazineBookmark.builder()
+				.user(user)
+				.magazine(magazine)
+				.build());
+			return true;
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public List<MagazineResDto> getBookmarkedMagazines(Long userId, MagazineCategory category) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+
+		MagazineCategory targetCategory = (category != null) ? category : MagazineCategory.PRICE;
+
+		List<MagazineBookmark> bookmarks =
+			bookmarkRepository.findByUserAndMagazineCategoryOrderByCreatedAtDesc(user, targetCategory);
+
+		return bookmarks.stream()
+			.map(bookmark -> MagazineConverter.from(bookmark.getMagazine()))
+			.toList();
+	}
+}

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -57,6 +57,10 @@ public enum ErrorCode {
 	// ADDRESS
 	ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "배송지 정보를 찾을 수 없습니다.", "ADDRESS-001"),
 	ADDRESS_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 배송지만 수정/삭제할 수 있습니다.", "ADDRESS-002"),
+
+	// MAGAZINE
+	MAGAZINE_NOT_FOUND(HttpStatus.NOT_FOUND, "매거진을 찾을 수 없습니다.", "MAG-001"),
+	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.", "COMM-002"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
@@ -77,9 +77,12 @@ public class SecurityConfig {
 				.requestMatchers("/api/users/me/**").authenticated()
 				.requestMatchers("/api/users/**").authenticated()
 
-				.requestMatchers("/api/magazines/**").permitAll()
+				//[11] 매거진
+				.requestMatchers(HttpMethod.POST, "/api/magazines/**/bookmark").authenticated()
+				.requestMatchers(HttpMethod.POST, "/api/magazines/comments/**").authenticated()
+				.requestMatchers(HttpMethod.POST, "/api/magazines/**/like").authenticated()
+				.requestMatchers(HttpMethod.GET, "/api/magazines/**").permitAll()
 
-				// [11] 그 외 모든 요청은 인증 필요
 				.anyRequest().authenticated()
 			)
 

--- a/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
@@ -77,6 +77,8 @@ public class SecurityConfig {
 				.requestMatchers("/api/users/me/**").authenticated()
 				.requestMatchers("/api/users/**").authenticated()
 
+				.requestMatchers("/api/magazines/**").permitAll()
+
 				// [11] 그 외 모든 요청은 인증 필요
 				.anyRequest().authenticated()
 			)


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #54 
* 네이버 뉴스 기반 매거진 데이터 크롤링 기능 구현
* 매거진 관련 커뮤니티 기능
  * 커뮤니티 기능(북마크, 댓글, 좋아요)을 위한 도메인 추가

## ✨ 상세 설명
* **Jsoup 기반 크롤링:** 네이버 뉴스 검색 결과를 최신순(`sort=0`)으로 파싱하여 매거진 데이터 수집 로직 구현
* **중복 필터링:** DB에 저장된 기존 URL과의 비교(`findAllUrlsByUrlIn`)를 통해 이미 수집된 기사는 중복 저장되지 않도록 처리
* **스케줄러 등록:** 매주 월요일 새벽 3시(`0 0 3 ? * MON`)에 자동 실행되도록 설정
* **비동기 수동 API:** 데이터 추가가 필요할 때를 대비해 관리자용 수동 크롤링 API 제공
    * `@Hidden` 어노테이션을 사용하여 Swagger에는 노출되지 않도록 처리
    * 비동기 방식으로 구현하여 클라이언트 타임아웃 방지
* **도메인 엔티티 확장:** 매거진 커뮤니티 기능을 위한 신규 테이블 설계 및 연관관계 매핑
    * `MagazineBookmark`: 사용자별 관심 매거진 저장
    * `MagazineCommentLike`: 매거진 댓글 공감 기능
    
## 🛠️ 추후 리팩토링 및 고도화 계획
* **콘텐츠 파싱 확장:** 네이버 뉴스 외에 다양한 패션 전문 웹진(무신사, 온큐레이션 등)으로 수집 채널 확장
* **성능 최적화**

## 📸 스크린샷 (선택)
<img width="599" height="110" alt="스크린샷 2026-01-30 오후 3 09 51" src="https://github.com/user-attachments/assets/52a42cfc-a9a5-4c8d-8fc6-bfa891322c2d" />
<img width="820" height="858" alt="스크린샷 2026-01-30 오후 3 10 20" src="https://github.com/user-attachments/assets/bb0f44bc-f62f-4a6e-a6dd-975ac04ee4f1" />

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  - 매거진 추천, 카테고리별 목록 및 상세 조회(조회수 집계) 제공
  - 관심 매거진 북마크 추가/해제 및 북마크 목록 조회
  - 매거진 댓글 작성, 댓글 목록, 댓글 좋아요 토글 기능
  - 수동/정기 자동 크롤링으로 매거진 콘텐츠 수집 및 주기적 업데이트

* **변경**
  - 일부 작성/조작(북마크·댓글·좋아요) API는 인증 필요로 변경

* **잡무**
  - 크롤링 관련 런타임 라이브러리 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->