### PR TITLE
[Feat] 상품 상세 페이지 실시간 조회 인원 WebSocket 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/ongil/backend/domain/product/websocket/controller/ProductViewerController.java
+++ b/src/main/java/com/ongil/backend/domain/product/websocket/controller/ProductViewerController.java
@@ -1,5 +1,7 @@
 package com.ongil.backend.domain.product.websocket.controller;
 
+import java.util.Map;
+
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -35,9 +37,6 @@ public class ProductViewerController {
 	 * 상품 상세 페이지 입장 처리
 	 * <p>
 	 * 클라이언트가 /app/products/{productId}/enter 로 메시지를 보내면 호출됩니다.
-	 *
-	 * @param productId      상품 ID (URL path에서 추출)
-	 * @param headerAccessor WebSocket 세션 정보 접근용
 	 */
 	@MessageMapping("/products/{productId}/enter")
 	public void enterProduct(
@@ -47,10 +46,13 @@ public class ProductViewerController {
 		String sessionId = headerAccessor.getSessionId();
 
 		// 세션에 현재 보고 있는 상품 ID 저장 (비정상 종료 시 정리용)
-		headerAccessor.getSessionAttributes().put("productId", productId);
+		Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+		if (sessionAttributes != null) {
+			sessionAttributes.put("productId", productId);
+		}
 
 		productViewerService.addViewer(productId, sessionId);
-		log.info("상품 입장: productId={}, sessionId={}", productId, sessionId);
+		log.debug("상품 입장: productId={}, sessionId={}", productId, sessionId);
 	}
 
 	/**
@@ -58,9 +60,6 @@ public class ProductViewerController {
 	 * <p>
 	 * 클라이언트가 /app/products/{productId}/leave 로 메시지를 보내면 호출됩니다.
 	 * 정상적인 페이지 이탈 시 호출됩니다.
-	 *
-	 * @param productId      상품 ID (URL path에서 추출)
-	 * @param headerAccessor WebSocket 세션 정보 접근용
 	 */
 	@MessageMapping("/products/{productId}/leave")
 	public void leaveProduct(
@@ -69,10 +68,12 @@ public class ProductViewerController {
 	) {
 		String sessionId = headerAccessor.getSessionId();
 
-		// 세션에서 상품 ID 제거
-		headerAccessor.getSessionAttributes().remove("productId");
+		Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+		if (sessionAttributes != null) {
+			sessionAttributes.remove("productId");
+		}
 
 		productViewerService.removeViewer(productId, sessionId);
-		log.info("상품 퇴장: productId={}, sessionId={}", productId, sessionId);
+		log.debug("상품 퇴장: productId={}, sessionId={}", productId, sessionId);
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/product/websocket/controller/ProductViewerController.java
+++ b/src/main/java/com/ongil/backend/domain/product/websocket/controller/ProductViewerController.java
@@ -1,0 +1,78 @@
+package com.ongil.backend.domain.product.websocket.controller;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Controller;
+
+import com.ongil.backend.domain.product.websocket.service.ProductViewerService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 상품 실시간 조회 인원 WebSocket 컨트롤러
+ * <p>
+ * 클라이언트의 입장/퇴장 메시지를 처리합니다.
+ * <p>
+ * [사용 흐름]
+ * 1. 클라이언트가 /ws 엔드포인트로 WebSocket 연결
+ * 2. /topic/products/{productId}/viewers 구독
+ * 3. /app/products/{productId}/enter 로 입장 메시지 전송
+ * 4. 서버가 현재 인원 수를 구독자들에게 브로드캐스트
+ * 5. 페이지 이탈 시 /app/products/{productId}/leave 로 퇴장 메시지 전송
+ */
+@Tag(name = "Product WebSocket", description = "상품 실시간 조회 인원 WebSocket API(스웨거 테스트는 불가)")
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ProductViewerController {
+
+	private final ProductViewerService productViewerService;
+
+	/**
+	 * 상품 상세 페이지 입장 처리
+	 * <p>
+	 * 클라이언트가 /app/products/{productId}/enter 로 메시지를 보내면 호출됩니다.
+	 *
+	 * @param productId      상품 ID (URL path에서 추출)
+	 * @param headerAccessor WebSocket 세션 정보 접근용
+	 */
+	@MessageMapping("/products/{productId}/enter")
+	public void enterProduct(
+		@DestinationVariable Long productId,
+		SimpMessageHeaderAccessor headerAccessor
+	) {
+		String sessionId = headerAccessor.getSessionId();
+
+		// 세션에 현재 보고 있는 상품 ID 저장 (비정상 종료 시 정리용)
+		headerAccessor.getSessionAttributes().put("productId", productId);
+
+		productViewerService.addViewer(productId, sessionId);
+		log.info("상품 입장: productId={}, sessionId={}", productId, sessionId);
+	}
+
+	/**
+	 * 상품 상세 페이지 퇴장 처리
+	 * <p>
+	 * 클라이언트가 /app/products/{productId}/leave 로 메시지를 보내면 호출됩니다.
+	 * 정상적인 페이지 이탈 시 호출됩니다.
+	 *
+	 * @param productId      상품 ID (URL path에서 추출)
+	 * @param headerAccessor WebSocket 세션 정보 접근용
+	 */
+	@MessageMapping("/products/{productId}/leave")
+	public void leaveProduct(
+		@DestinationVariable Long productId,
+		SimpMessageHeaderAccessor headerAccessor
+	) {
+		String sessionId = headerAccessor.getSessionId();
+
+		// 세션에서 상품 ID 제거
+		headerAccessor.getSessionAttributes().remove("productId");
+
+		productViewerService.removeViewer(productId, sessionId);
+		log.info("상품 퇴장: productId={}, sessionId={}", productId, sessionId);
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/product/websocket/dto/ViewerCountMessage.java
+++ b/src/main/java/com/ongil/backend/domain/product/websocket/dto/ViewerCountMessage.java
@@ -1,0 +1,15 @@
+package com.ongil.backend.domain.product.websocket.dto;
+
+/**
+ * 실시간 조회 인원 수 메시지 DTO
+ *
+ * 클라이언트에게 브로드캐스트되는 메시지 형식입니다.
+ */
+public record ViewerCountMessage(
+	Long productId,
+	Long viewerCount
+) {
+	public static ViewerCountMessage of(Long productId, Long viewerCount) {
+		return new ViewerCountMessage(productId, viewerCount);
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/product/websocket/service/ProductViewerService.java
+++ b/src/main/java/com/ongil/backend/domain/product/websocket/service/ProductViewerService.java
@@ -1,0 +1,79 @@
+package com.ongil.backend.domain.product.websocket.service;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import com.ongil.backend.domain.product.websocket.dto.ViewerCountMessage;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 상품 실시간 조회 인원 관리 서비스
+ * <p>
+ * Redis Set 자료구조를 사용하여 각 상품별 조회 중인 세션 ID를 관리합니다.
+ * - Set을 사용하면 중복 방지 및 O(1) 시간에 추가/삭제가 가능합니다.
+ * - TTL을 설정하여 비정상 종료 시에도 일정 시간 후 자동 정리됩니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductViewerService {
+
+	private final StringRedisTemplate redisTemplate;
+	private final SimpMessagingTemplate messagingTemplate;
+
+	private static final String VIEWER_KEY_PREFIX = "product:viewers:";
+	private static final long VIEWER_TTL_MINUTES = 30;  // 비정상 종료 대비 TTL
+
+	// 상품 조회 입장 처리
+	public void addViewer(Long productId, String sessionId) {
+		String key = VIEWER_KEY_PREFIX + productId;
+
+		// Redis Set에 세션 ID 추가
+		redisTemplate.opsForSet().add(key, sessionId);
+
+		// TTL 갱신 (30분 후 자동 삭제)
+		redisTemplate.expire(key, VIEWER_TTL_MINUTES, TimeUnit.MINUTES);
+
+		log.debug("Viewer 추가: productId={}, sessionId={}", productId, sessionId);
+
+		// 변경된 인원 수 브로드캐스트
+		broadcastViewerCount(productId);
+	}
+
+	// 상품 조회 퇴장 처리
+	public void removeViewer(Long productId, String sessionId) {
+		String key = VIEWER_KEY_PREFIX + productId;
+
+		// Redis Set에서 세션 ID 제거
+		redisTemplate.opsForSet().remove(key, sessionId);
+
+		log.debug("Viewer 제거: productId={}, sessionId={}", productId, sessionId);
+
+		// 변경된 인원 수 브로드캐스트
+		broadcastViewerCount(productId);
+	}
+
+	// 특정 상품의 현재 조회 인원 수 조회
+	public Long getViewerCount(Long productId) {
+		String key = VIEWER_KEY_PREFIX + productId;
+		Long count = redisTemplate.opsForSet().size(key);
+		return count != null ? count : 0L;
+	}
+
+	// 변경된 조회 인원 수를 구독자들에게 브로드캐스트
+	private void broadcastViewerCount(Long productId) {
+		Long viewerCount = getViewerCount(productId);
+		ViewerCountMessage message = ViewerCountMessage.of(productId, viewerCount);
+
+		// /topic/products/{productId}/viewers 를 구독 중인 클라이언트에게 전송
+		String destination = "/topic/products/" + productId + "/viewers";
+		messagingTemplate.convertAndSend(destination, message);
+
+		log.debug("Viewer count 브로드캐스트: productId={}, count={}", productId, viewerCount);
+	}
+}

--- a/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
@@ -38,6 +38,9 @@ public class SecurityConfig {
 				// [1] 시스템 및 문서화 관련 (Swagger, H2 Console)
 				.requestMatchers("/ping", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 
+				// WebSocket
+				.requestMatchers("/ws/**").permitAll()
+
 				// [2] 인증 관련 - 인증 필요
 				.requestMatchers("/api/auth/logout", "/api/auth/withdraw").authenticated()
 

--- a/src/main/java/com/ongil/backend/global/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/websocket/WebSocketConfig.java
@@ -1,0 +1,40 @@
+package com.ongil.backend.global.config.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * WebSocket + STOMP 설정
+ * <p>
+ * STOMP(Simple Text Oriented Messaging Protocol)를 사용하여
+ * 메시지 기반의 양방향 통신을 구현합니다.
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	/**
+	 * STOMP 엔드포인트 등록
+	 * 클라이언트는 이 엔드포인트로 WebSocket 연결을 수립합니다.
+	 */
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws") // WebSocket 엔드포인트 URL(연결 url)
+			.setAllowedOriginPatterns("*")
+			.withSockJS();
+	}
+
+	/**
+	 * 메시지 브로커 설정
+	 */
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		// 서버 -> 클라이언트, 구독용
+		registry.enableSimpleBroker("/topic");
+		// 클라이언트 -> 서버
+		registry.setApplicationDestinationPrefixes("/app");
+	}
+}

--- a/src/main/java/com/ongil/backend/global/config/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/ongil/backend/global/config/websocket/WebSocketEventListener.java
@@ -1,0 +1,53 @@
+package com.ongil.backend.global.config.websocket;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import com.ongil.backend.domain.product.websocket.service.ProductViewerService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * WebSocket 세션 이벤트 리스너
+ * <p>
+ * 클라이언트의 연결/해제 이벤트를 감지하여 처리합니다.
+ * 특히 비정상 종료(브라우저 강제 종료 등) 시에도 세션 정리가 가능합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketEventListener {
+
+	private final ProductViewerService productViewerService;
+
+	// WebSocket 연결 시 호출
+	@EventListener
+	public void handleWebSocketConnectListener(SessionConnectEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = headerAccessor.getSessionId();
+		log.debug("WebSocket 연결: sessionId={}", sessionId);
+	}
+
+	/**
+	 * WebSocket 연결 해제 시 호출
+	 * 정상 or 비정상(브라우저 종료, 네트워크 끊김 등) 모든 종료 상황에서 호출됩니다.
+	 */
+	@EventListener
+	public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = headerAccessor.getSessionId();
+
+		// 세션에 저장된 productId가 있으면 조회 인원에서 제거
+		Long productId = (Long)headerAccessor.getSessionAttributes().get("productId");
+		if (productId != null) {
+			productViewerService.removeViewer(productId, sessionId);
+			log.debug("비정상 종료로 인한 viewer 제거: productId={}, sessionId={}", productId, sessionId);
+		}
+
+		log.debug("WebSocket 연결 해제: sessionId={}", sessionId);
+	}
+}

--- a/src/main/java/com/ongil/backend/global/config/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/ongil/backend/global/config/websocket/WebSocketEventListener.java
@@ -1,5 +1,7 @@
 package com.ongil.backend.global.config.websocket;
 
+import java.util.Map;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
@@ -42,12 +44,16 @@ public class WebSocketEventListener {
 		String sessionId = headerAccessor.getSessionId();
 
 		// 세션에 저장된 productId가 있으면 조회 인원에서 제거
-		Long productId = (Long)headerAccessor.getSessionAttributes().get("productId");
+		Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+		if (sessionAttributes == null) {
+			log.debug("Session attributes is null. sessionId={}", sessionId);
+			return;
+		}
+
+		Long productId = (Long)sessionAttributes.get("productId");
 		if (productId != null) {
 			productViewerService.removeViewer(productId, sessionId);
 			log.debug("비정상 종료로 인한 viewer 제거: productId={}, sessionId={}", productId, sessionId);
 		}
-
-		log.debug("WebSocket 연결 해제: sessionId={}", sessionId);
 	}
 }


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
상품 상세 페이지 실시간 조회 인원 WebSocket 기능 추가

## ✨ 상세 설명
상품 상세 페이지에서 현재 조회 중인 인원을 실시간으로 표시하기 위해  
WebSocket(STOMP)과 Redis를 활용한 조회 인원 관리 기능을 구현했습니다.

클라이언트는 상품 상세 페이지 진입 시 WebSocket 연결 후 해당 상품의 조회 인원 토픽을 구독하며,  
입장(`/enter`) 및 퇴장(`/leave`) 이벤트를 서버로 전송합니다.  
서버는 WebSocket 세션 ID를 기준으로 Redis Set에 조회 중인 세션을 관리하고,  
인원 변경 시마다 해당 상품을 구독 중인 모든 클라이언트에게 최신 조회 인원 수를 브로드캐스트합니다.

또한 브라우저 종료, 네트워크 끊김 등 비정상 종료 상황을 대비해  
WebSocket Disconnect 이벤트를 감지하여 조회 인원을 자동 정리하도록 구성했으며,  
Redis TTL을 설정하여 예외 상황에서도 데이터가 누적되지 않도록 처리했습니다.

이를 통해 서버 다중 인스턴스 환경에서도 일관된 실시간 조회 인원 동기화가 가능하도록 설계했습니다.

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 상품 페이지에 실시간 조회자 수 기능이 추가되었습니다: 사용자가 상품에 접속·이탈하면 조회자 수가 자동 집계·브로드캐스트되어 화면에 실시간 반영됩니다.
  * WebSocket 기반 실시간 통신이 도입되어 클라이언트-서버 간 실시간 업데이트가 가능해졌습니다.
  * WebSocket 연결 종료 시 자동 정리 및 조회자 수 동기화가 이루어집니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->