### PR TITLE
[Fix] 상위 카테고리로도 그 아래 하위 카테고리들의 상품 조회가 가능하게 수정

### DIFF
--- a/src/main/java/com/ongil/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ongil/backend/domain/admin/service/AdminService.java
@@ -19,12 +19,13 @@ import com.ongil.backend.domain.product.converter.ProductConverter;
 import com.ongil.backend.domain.product.dto.response.ProductOptionResponse;
 import com.ongil.backend.domain.product.dto.response.ProductSimpleResponse;
 import com.ongil.backend.domain.product.entity.Product;
-import com.ongil.backend.domain.product.enums.ProductType;
 import com.ongil.backend.domain.product.entity.ProductOption;
+import com.ongil.backend.domain.product.enums.ProductType;
 import com.ongil.backend.domain.product.repository.ProductOptionRepository;
 import com.ongil.backend.domain.product.repository.ProductRepository;
 import com.ongil.backend.global.common.exception.EntityNotFoundException;
 import com.ongil.backend.global.common.exception.ErrorCode;
+import com.ongil.backend.global.common.exception.ValidationException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -76,6 +77,11 @@ public class AdminService {
 
 		Category category = categoryRepository.findById(request.getCategoryId())
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
+
+		// 상품은 하위 카테고리에만 등록 가능
+		if (category.getParentCategory() == null) {
+			throw new ValidationException(ErrorCode.INVALID_CATEGORY);
+		}
 
 		Integer discountPrice = null;
 		if (request.getPrice() != null && request.getDiscountRate() != null && request.getDiscountRate() > 0) {

--- a/src/main/java/com/ongil/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/ongil/backend/domain/product/repository/ProductRepository.java
@@ -25,7 +25,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	@EntityGraph(attributePaths = {"brand", "category", "category.parentCategory"})
 	Optional<Product> findWithBrandAndCategoryById(Long id);
 
-	// 조건에 따른 상품 조회
+	// 조건에 따른 상품 조회 (하위 카테고리)
 	@EntityGraph(attributePaths = {"brand", "category"})
 	@Query("""
     SELECT p FROM Product p
@@ -40,6 +40,28 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	Page<Product> findAllByCondition(
 		@Param("targetIds") List<Long> targetIds,
 		@Param("categoryId") Long categoryId,
+		@Param("brandId") Long brandId,
+		@Param("minPrice") Integer minPrice,
+		@Param("maxPrice") Integer maxPrice,
+		@Param("size") String size,
+		Pageable pageable
+	);
+
+	// 조건에 따른 상품 조회 (상위 카테고리 - 하위 카테고리들의 상품 전체 조회)
+	@EntityGraph(attributePaths = {"brand", "category"})
+	@Query("""
+    SELECT p FROM Product p
+    WHERE (:targetIds IS NULL OR p.id IN :targetIds)
+      AND p.category.parentCategory.id = :parentCategoryId
+      AND (:brandId IS NULL OR p.brand.id = :brandId)
+      AND (:minPrice IS NULL OR p.price >= :minPrice)
+      AND (:maxPrice IS NULL OR p.price <= :maxPrice)
+      AND (:size IS NULL OR p.sizes LIKE CONCAT('%', :size, '%'))
+      AND p.onSale = true
+    """)
+	Page<Product> findAllByParentCategoryCondition(
+		@Param("targetIds") List<Long> targetIds,
+		@Param("parentCategoryId") Long parentCategoryId,
 		@Param("brandId") Long brandId,
 		@Param("minPrice") Integer minPrice,
 		@Param("maxPrice") Integer maxPrice,

--- a/src/main/java/com/ongil/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/ongil/backend/domain/product/service/ProductService.java
@@ -28,6 +28,8 @@ import com.ongil.backend.domain.search.service.SearchService;
 import com.ongil.backend.domain.search.validator.SearchValidator;
 import com.ongil.backend.domain.user.entity.User;
 import com.ongil.backend.domain.user.repository.UserRepository;
+import com.ongil.backend.domain.category.entity.Category;
+import com.ongil.backend.domain.category.repository.CategoryRepository;
 import com.ongil.backend.global.common.exception.EntityNotFoundException;
 import com.ongil.backend.global.common.exception.ErrorCode;
 
@@ -48,6 +50,7 @@ public class ProductService {
 	private final SizeGuideConverter sizeGuideConverter;
 	private final SearchService searchService;
 	private final RecentSearchService recentSearchService;
+	private final CategoryRepository categoryRepository;
 
 	private static final int SIMILAR_CUSTOMERS_LIMIT = 4;
 
@@ -98,15 +101,48 @@ public class ProductService {
 			sort
 		);
 
-		Page<Product> products = productRepository.findAllByCondition(
-			targetIds,
-			condition.getCategoryId(),
-			condition.getBrandId(),
-			minPrice,
-			maxPrice,
-			condition.getSize(),
-			pageableWithSort
-		);
+		Page<Product> products;
+
+		// categoryId가 있으면 상위/하위 카테고리 판단 후 분기 처리
+		if (condition.getCategoryId() != null) {
+			Category category = categoryRepository.findById(condition.getCategoryId())
+				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
+
+			if (category.getParentCategory() == null) {
+				// 상위 카테고리 → 하위 카테고리들의 상품 전체 조회
+				products = productRepository.findAllByParentCategoryCondition(
+					targetIds,
+					condition.getCategoryId(),
+					condition.getBrandId(),
+					minPrice,
+					maxPrice,
+					condition.getSize(),
+					pageableWithSort
+				);
+			} else {
+				// 하위 카테고리 → 해당 카테고리 상품만 조회
+				products = productRepository.findAllByCondition(
+					targetIds,
+					condition.getCategoryId(),
+					condition.getBrandId(),
+					minPrice,
+					maxPrice,
+					condition.getSize(),
+					pageableWithSort
+				);
+			}
+		} else {
+			// categoryId가 없으면 전체 상품 조회
+			products = productRepository.findAllByCondition(
+				targetIds,
+				null,
+				condition.getBrandId(),
+				minPrice,
+				maxPrice,
+				condition.getSize(),
+				pageableWithSort
+			);
+		}
 
 		// 추천 검색어에 이용하기 위한 과정
 		if (hasQuery && !products.isEmpty()) {

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
 
 	// CATEGORY
 	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다.", "CATEGORY-001"),
+	INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "상품은 하위 카테고리에만 등록할 수 있습니다.", "CATEGORY-002"),
 
 	// WISHLIST
 	WISHLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "찜을 찾을 수 없습니다.", "WISHLIST-001"),


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
상위 카테고리로도 그 아래 하위 카테고리들의 상품 조회가 가능하게 수정
## ✨ 상세 설명
- 초기에는 상위 카테고리로 상품 조회시 빈배열 반환하는 문제가 있었습니다. 그렇기에 프론트 측에서 상위 카테고리로 조회시에 그 아래 하위 카테고리의 모든 상품들을 조회 가능하게 기능 구현을 했음 좋겠다는 의견을 반영했습니다. 
- ex) 아우터로 상품 조회시 아우터가 상위 카테고리인 모든 하위 카테고리의 상품 목록을 조회하게 됩니다. 
## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)
<img width="691" height="476" alt="image" src="https://github.com/user-attachments/assets/fabb84f6-3254-4980-8a4c-99b5c7e74780" />

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리별 제품 검색이 개선되었습니다. 상위(루트) 카테고리 선택 시 하위 카테고리의 제품도 함께 조회되고, 하위 카테고리 선택 시 해당 카테고리 제품만 표시됩니다.
* **버그 수정 / 검증 강화**
  * 상품 등록 시 상위(루트) 카테고리로의 등록이 차단되며, 하위 카테고리만 등록할 수 있도록 검증 및 관련 오류 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->