### PR TITLE
[Feat] 실시간 알림 구현 (스케줄러 + SSE)

### DIFF
--- a/src/main/java/com/ongil/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/ongil/backend/domain/notification/controller/NotificationController.java
@@ -1,0 +1,71 @@
+package com.ongil.backend.domain.notification.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.ongil.backend.domain.notification.dto.response.NotificationResponse;
+import com.ongil.backend.domain.notification.service.NotificationService;
+import com.ongil.backend.domain.notification.service.NotificationSseService;
+import com.ongil.backend.global.common.dto.DataResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Notification", description = "알림 API")
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+	private final NotificationService notificationService;
+	private final NotificationSseService notificationSseService;
+
+	@Operation(summary = "SSE 연결", description = "실시간 알림을 받기 위한 SSE 연결. 연결 유지 필요.")
+	@GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter subscribe(@AuthenticationPrincipal Long userId) {
+		return notificationSseService.subscribe(userId);
+	}
+
+	@Operation(summary = "알림 목록 조회", description = "읽지 않은 알림 목록을 조회합니다.")
+	@GetMapping
+	public DataResponse<List<NotificationResponse>> getNotifications(
+		@AuthenticationPrincipal Long userId) {
+
+		List<NotificationResponse> notifications = notificationService.getUnreadNotifications(userId);
+		return DataResponse.from(notifications);
+	}
+
+	@Operation(summary = "알림 개수 조회", description = "읽지 않은 알림 개수를 조회합니다. (뱃지 표시용)")
+	@GetMapping("/count")
+	public DataResponse<Map<String, Long>> getUnreadCount(
+		@AuthenticationPrincipal Long userId) {
+
+		long count = notificationService.getUnreadCount(userId);
+		return DataResponse.from(Map.of("count", count));
+	}
+
+	@Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 처리합니다.")
+	@PatchMapping("/{notificationId}/read")
+	public DataResponse<Void> markAsRead(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long notificationId) {
+
+		notificationService.markAsRead(userId, notificationId);
+		return DataResponse.ok();
+	}
+
+	@Operation(summary = "모든 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
+	@PatchMapping("/read-all")
+	public DataResponse<Void> markAllAsRead(
+		@AuthenticationPrincipal Long userId) {
+
+		notificationService.markAllAsRead(userId);
+		return DataResponse.ok();
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/ongil/backend/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,17 @@
+package com.ongil.backend.domain.notification.converter;
+
+import com.ongil.backend.domain.notification.dto.response.NotificationResponse;
+import com.ongil.backend.domain.notification.entity.Notification;
+
+public class NotificationConverter {
+
+	public static NotificationResponse toResponse(Notification notification) {
+		return NotificationResponse.builder()
+			.notificationId(notification.getId())
+			.message(notification.getMessage())
+			.targetUrl(notification.getTargetUrl())
+			.read(notification.getIsRead())
+			.notifiedAt(notification.getNotifiedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/ongil/backend/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,28 @@
+package com.ongil.backend.domain.notification.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "알림 응답")
+public class NotificationResponse {
+
+	@Schema(description = "알림 ID", example = "1")
+	private Long notificationId;
+
+	@Schema(description = "알림 메시지", example = "오버핏 니트이(가) 47,500원으로 할인되었습니다!")
+	private String message;
+
+	@Schema(description = "클릭 시 이동할 URL", example = "/products/1")
+	private String targetUrl;
+
+	@Schema(description = "읽음 여부", example = "false")
+	private boolean read;
+
+	@Schema(description = "알림 발송 시각")
+	private LocalDateTime notifiedAt;
+}

--- a/src/main/java/com/ongil/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/ongil/backend/domain/notification/entity/Notification.java
@@ -1,0 +1,62 @@
+package com.ongil.backend.domain.notification.entity;
+
+import java.time.LocalDateTime;
+
+import com.ongil.backend.domain.product.entity.Product;
+import com.ongil.backend.domain.user.entity.User;
+import com.ongil.backend.global.common.entity.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notifications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Notification extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_id")
+	private Long id;
+
+	@Column(name = "message", nullable = false)
+	private String message;
+
+	@Column(name = "target_url", nullable = false)
+	private String targetUrl;
+
+	@Column(name = "is_read", nullable = false)
+	private Boolean isRead = false;
+
+	@Column(name = "read_at")
+	private LocalDateTime readAt;
+	
+	@Column(name = "notified_at", nullable = false)
+	private LocalDateTime notifiedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "product_id", nullable = false)
+	private Product product;
+
+	@Builder
+	public Notification(String message, String targetUrl, LocalDateTime notifiedAt, User user, Product product) {
+		this.message = message;
+		this.targetUrl = targetUrl;
+		this.notifiedAt = notifiedAt;
+		this.user = user;
+		this.product = product;
+	}
+
+	public void markAsRead() {
+		this.isRead = true;
+		this.readAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ongil/backend/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,16 @@
+package com.ongil.backend.domain.notification.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ongil.backend.domain.notification.entity.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	// 해당 사용자의 읽지 않은 알림 전체 조회 (알림 탭용)
+	List<Notification> findByUserIdAndIsReadFalseOrderByNotifiedAtDesc(Long userId);
+
+	// 해당 사용자의 읽지 않은 알림 개수 조회 (알림 아이콘 뱅지용)
+	long countByUserIdAndIsReadFalse(Long userId);
+}

--- a/src/main/java/com/ongil/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/ongil/backend/domain/notification/service/NotificationService.java
@@ -1,0 +1,62 @@
+package com.ongil.backend.domain.notification.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ongil.backend.domain.notification.converter.NotificationConverter;
+import com.ongil.backend.domain.notification.dto.response.NotificationResponse;
+import com.ongil.backend.domain.notification.entity.Notification;
+import com.ongil.backend.domain.notification.repository.NotificationRepository;
+import com.ongil.backend.global.common.exception.EntityNotFoundException;
+import com.ongil.backend.global.common.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	private final NotificationRepository notificationRepository;
+
+	// 읽지 않은 알림 목록 조회
+	@Transactional(readOnly = true)
+	public List<NotificationResponse> getUnreadNotifications(Long userId) {
+		List<Notification> notifications = notificationRepository
+			.findByUserIdAndIsReadFalseOrderByNotifiedAtDesc(userId);
+
+		return notifications.stream()
+			.map(NotificationConverter::toResponse)
+			.toList();
+	}
+
+	// 읽지 않은 알림 개수 조회
+	@Transactional(readOnly = true)
+	public long getUnreadCount(Long userId) {
+		return notificationRepository.countByUserIdAndIsReadFalse(userId);
+	}
+
+	// 개별 알림 읽음 처리
+	@Transactional
+	public void markAsRead(Long userId, Long notificationId) {
+		Notification notification = notificationRepository.findById(notificationId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+		// 본인의 알림인지 확인
+		if (!notification.getUser().getId().equals(userId)) {
+			throw new EntityNotFoundException(ErrorCode.NOTIFICATION_NOT_FOUND);
+		}
+
+		notification.markAsRead();
+	}
+
+	// 모든 알림 읽음 처리
+	@Transactional
+	public void markAllAsRead(Long userId) {
+		List<Notification> notifications = notificationRepository
+			.findByUserIdAndIsReadFalseOrderByNotifiedAtDesc(userId);
+
+		notifications.forEach(Notification::markAsRead);
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/notification/service/NotificationSseService.java
+++ b/src/main/java/com/ongil/backend/domain/notification/service/NotificationSseService.java
@@ -1,0 +1,88 @@
+package com.ongil.backend.domain.notification.service;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.ongil.backend.domain.notification.dto.response.NotificationResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class NotificationSseService {
+
+	// 유저별 SSE 연결 관리
+	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+	private static final Long SSE_TIMEOUT = 30 * 60 * 1000L; // 30분
+
+	// SSE 구독 생성
+	public SseEmitter subscribe(Long userId) {
+		// 기존 연결이 있으면 제거
+		if (emitters.containsKey(userId)) {
+			emitters.get(userId).complete();
+			emitters.remove(userId);
+		}
+
+		SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
+		emitters.put(userId, emitter);
+
+		// 연결 종료 시 제거
+		emitter.onCompletion(() -> {
+			emitters.remove(userId);
+			log.info("SSE 연결 종료 - userId: {}", userId);
+		});
+
+		emitter.onTimeout(() -> {
+			emitters.remove(userId);
+			log.info("SSE 타임아웃 - userId: {}", userId);
+		});
+
+		emitter.onError(e -> {
+			emitters.remove(userId);
+			log.error("SSE 에러 - userId: {}", userId, e);
+		});
+
+		// 연결 직후 더미 이벤트 전송 (연결 확인용)
+		try {
+			emitter.send(SseEmitter.event()
+				.name("connect")
+				.data("SSE 연결 성공"));
+		} catch (IOException e) {
+			emitters.remove(userId);
+			log.error("SSE 초기 이벤트 전송 실패 - userId: {}", userId, e);
+		}
+
+		log.info("SSE 연결 생성 - userId: {}", userId);
+		return emitter;
+	}
+
+	// 알림 전송
+	public void sendNotification(Long userId, NotificationResponse notification) {
+		SseEmitter emitter = emitters.get(userId);
+
+		if (emitter == null) {
+			log.debug("SSE 연결 없음 - userId: {}", userId);
+			return;
+		}
+
+		try {
+			emitter.send(SseEmitter.event()
+				.name("price-alert")
+				.data(notification));
+			log.info("SSE 알림 전송 성공 - userId: {}, notificationId: {}", userId, notification.getNotificationId());
+		} catch (IOException e) {
+			emitters.remove(userId);
+			log.error("SSE 알림 전송 실패 - userId: {}", userId, e);
+		}
+	}
+
+	// 현재 연결된 사용자 수 조회 (디버깅용)
+	public int getConnectedUserCount() {
+		return emitters.size();
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/notification/service/NotificationSseService.java
+++ b/src/main/java/com/ongil/backend/domain/notification/service/NotificationSseService.java
@@ -22,10 +22,10 @@ public class NotificationSseService {
 
 	// SSE 구독 생성
 	public SseEmitter subscribe(Long userId) {
-		// 기존 연결이 있으면 제거
-		if (emitters.containsKey(userId)) {
-			emitters.get(userId).complete();
-			emitters.remove(userId);
+		// 기존 연결이 있으면 제거 (원자적 연산)
+		SseEmitter existingEmitter = emitters.remove(userId);
+		if (existingEmitter != null) {
+			existingEmitter.complete();
 		}
 
 		SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);

--- a/src/main/java/com/ongil/backend/domain/pricealert/controller/PriceAlertController.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/controller/PriceAlertController.java
@@ -1,0 +1,45 @@
+package com.ongil.backend.domain.pricealert.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.ongil.backend.domain.pricealert.dto.request.PriceAlertRequest;
+import jakarta.validation.Valid;
+import com.ongil.backend.domain.pricealert.dto.response.PriceAlertResponse;
+import com.ongil.backend.domain.pricealert.service.PriceAlertService;
+import com.ongil.backend.global.common.dto.DataResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Price Alert", description = "할인 알림 API")
+@RestController
+@RequestMapping("/api/price-alerts")
+@RequiredArgsConstructor
+public class PriceAlertController {
+
+	private final PriceAlertService priceAlertService;
+
+	// 할인 알림 설정 & 재설정
+	@Operation(summary = "할인 알림 설정", description = "기존 알림이 있으면 자동으로 재설정됨")
+	@PostMapping
+	public DataResponse<Void> createPriceAlert(
+		@AuthenticationPrincipal Long userId,
+		@RequestBody @Valid PriceAlertRequest request) {
+
+		priceAlertService.createOrUpdatePriceAlert(userId, request);
+		return DataResponse.ok();
+	}
+
+	// 현재 활성 중인 알림 조회
+	@Operation(summary = "할인 알림 조회", description = "상품 상세 화면 진입 시 기존 설정 조회")
+	@GetMapping("/{productId}")
+	public DataResponse<PriceAlertResponse> getPriceAlert(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long productId) {
+
+		PriceAlertResponse response = priceAlertService.getPriceAlert(userId, productId);
+		return DataResponse.from(response);
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/pricealert/converter/PriceAlertConverter.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/converter/PriceAlertConverter.java
@@ -1,0 +1,17 @@
+package com.ongil.backend.domain.pricealert.converter;
+
+import com.ongil.backend.domain.pricealert.dto.response.PriceAlertResponse;
+import com.ongil.backend.domain.pricealert.entity.PriceAlert;
+
+public class PriceAlertConverter {
+
+	public static PriceAlertResponse toResponse(PriceAlert priceAlert) {
+		return PriceAlertResponse.builder()
+			.productId(priceAlert.getProduct().getId())
+			.currentPrice(priceAlert.getProduct().getPrice())
+			.targetPrice(priceAlert.getTargetPrice())
+			.isNotified(priceAlert.getIsNotified())
+			.isActive(priceAlert.getIsActive())
+			.build();
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/pricealert/dto/request/PriceAlertRequest.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/dto/request/PriceAlertRequest.java
@@ -1,0 +1,20 @@
+package com.ongil.backend.domain.pricealert.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "할인 알림 설정 요청")
+public class PriceAlertRequest {
+
+	@NotNull(message = "상품 ID는 필수입니다.")
+	@Schema(description = "상품 ID", example = "1")
+	private Long productId;
+
+	@NotNull(message = "목표 가격은 필수입니다.")
+	@Positive(message = "목표 가격은 양수여야 합니다.")
+	@Schema(description = "목표 가격 (사용자가 선택한 할인가)", example = "47500")
+	private Integer targetPrice;
+}

--- a/src/main/java/com/ongil/backend/domain/pricealert/dto/response/PriceAlertResponse.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/dto/response/PriceAlertResponse.java
@@ -1,0 +1,26 @@
+package com.ongil.backend.domain.pricealert.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "할인 알림 조회 응답")
+public class PriceAlertResponse {
+
+	@Schema(description = "상품 ID", example = "1")
+	private Long productId;
+
+	@Schema(description = "현재 판매가", example = "50000")
+	private Integer currentPrice;
+
+	@Schema(description = "사용자가 선택한 목표 가격", example = "47500")
+	private Integer targetPrice;
+
+	@Schema(description = "알림 발송 여부", example = "false")
+	private Boolean isNotified;
+
+	@Schema(description = "알림 설정 활성 여부", example = "true")
+	private Boolean isActive;
+}

--- a/src/main/java/com/ongil/backend/domain/pricealert/entity/PriceAlert.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/entity/PriceAlert.java
@@ -1,7 +1,5 @@
 package com.ongil.backend.domain.pricealert.entity;
 
-import java.time.LocalDateTime;
-
 import com.ongil.backend.domain.product.entity.Product;
 import com.ongil.backend.domain.user.entity.User;
 import com.ongil.backend.global.common.entity.BaseEntity;
@@ -27,13 +25,10 @@ public class PriceAlert extends BaseEntity {
 	private Integer targetPrice;
 
 	@Column(name = "is_active", nullable = false)
-	private Boolean isActive = true;
+	private Boolean isActive = true; // 알림 활성화 여부
 
-	@Column(name = "read_at")
-	private LocalDateTime readAt;
-
-	@Column(name = "is_read", nullable = false)
-	private Boolean isRead = false;
+	@Column(name = "is_notified", nullable = false)
+	private Boolean isNotified = false; // 알림 발송 여부
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
@@ -49,5 +44,13 @@ public class PriceAlert extends BaseEntity {
 		this.isActive = isActive;
 		this.user = user;
 		this.product = product;
+	}
+
+	public void markAsNotified() { // 가격 알림이 발송되었음을 표시
+		this.isNotified = true;
+	}
+
+	public void deactivate() { // 알림을 비활성화
+		this.isActive = false;
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/pricealert/repository/PriceAlertRepository.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/repository/PriceAlertRepository.java
@@ -1,8 +1,22 @@
 package com.ongil.backend.domain.pricealert.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.ongil.backend.domain.pricealert.entity.PriceAlert;
 
 public interface PriceAlertRepository extends JpaRepository<PriceAlert, Long> {
+
+	// 스케줄러용: 활성 중이고 아직 알림 미발송인 건 전체 조회 (N+1 방지를 위한 fetch join)
+	@Query("SELECT pa FROM PriceAlert pa " +
+		"JOIN FETCH pa.user " +
+		"JOIN FETCH pa.product " +
+		"WHERE pa.isActive = true AND pa.isNotified = false")
+	List<PriceAlert> findActiveAlertsWithUserAndProduct();
+
+	// 현재 활성 중인 알림 조회 (상품 상세 화면 진입 시)
+	Optional<PriceAlert> findByUserIdAndProductIdAndIsActiveTrue(Long userId, Long productId);
 }

--- a/src/main/java/com/ongil/backend/domain/pricealert/scheduler/PriceAlertScheduler.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/scheduler/PriceAlertScheduler.java
@@ -1,0 +1,68 @@
+package com.ongil.backend.domain.pricealert.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ongil.backend.domain.notification.converter.NotificationConverter;
+import com.ongil.backend.domain.notification.dto.response.NotificationResponse;
+import com.ongil.backend.domain.notification.entity.Notification;
+import com.ongil.backend.domain.notification.repository.NotificationRepository;
+import com.ongil.backend.domain.notification.service.NotificationSseService;
+import com.ongil.backend.domain.pricealert.entity.PriceAlert;
+import com.ongil.backend.domain.pricealert.repository.PriceAlertRepository;
+import com.ongil.backend.domain.product.entity.Product;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PriceAlertScheduler {
+
+	private final PriceAlertRepository priceAlertRepository;
+	private final NotificationRepository notificationRepository;
+	private final NotificationSseService notificationSseService;
+
+	@Scheduled(fixedRate = 30000) // 30초 간격
+	@Transactional
+	public void checkPriceAlerts() {
+
+		// 활성 중이고 알림 미발송인 건만 조회
+		List<PriceAlert> alerts = priceAlertRepository.findActiveAlertsWithUserAndProduct();
+
+		for (PriceAlert alert : alerts) {
+			Product product = alert.getProduct();
+			Integer currentPrice = product.getPrice();
+			Integer targetPrice = alert.getTargetPrice();
+
+			if (currentPrice <= targetPrice) {
+
+				// 1. PriceAlert의 isNotified를 true로 업데이트
+				alert.markAsNotified();
+
+				Notification notification = Notification.builder()
+					.message(product.getName() + "이(가) " + String.format("%,d", currentPrice) + "원으로 할인되었습니다!")
+					.targetUrl("/products/" + product.getId())
+					.notifiedAt(LocalDateTime.now())
+					.user(alert.getUser())
+					.product(product)
+					.build();
+
+				Notification savedNotification = notificationRepository.save(notification);
+
+				// 3. SSE로 실시간 알림 전송
+				Long userId = alert.getUser().getId();
+				NotificationResponse response = NotificationConverter.toResponse(savedNotification);
+				notificationSseService.sendNotification(userId, response);
+
+				log.info("할인 알림 발송 - userId: {}, productId: {}, currentPrice: {}, targetPrice: {}",
+					userId, product.getId(), currentPrice, targetPrice);
+			}
+		}
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/pricealert/service/PriceAlertService.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/service/PriceAlertService.java
@@ -1,0 +1,71 @@
+package com.ongil.backend.domain.pricealert.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ongil.backend.domain.pricealert.converter.PriceAlertConverter;
+import com.ongil.backend.domain.pricealert.dto.request.PriceAlertRequest;
+import com.ongil.backend.domain.pricealert.dto.response.PriceAlertResponse;
+import com.ongil.backend.domain.pricealert.entity.PriceAlert;
+import com.ongil.backend.domain.pricealert.repository.PriceAlertRepository;
+import com.ongil.backend.domain.product.entity.Product;
+import com.ongil.backend.domain.product.repository.ProductRepository;
+import com.ongil.backend.domain.user.entity.User;
+import com.ongil.backend.domain.user.repository.UserRepository;
+import com.ongil.backend.global.common.exception.EntityNotFoundException;
+import com.ongil.backend.global.common.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PriceAlertService {
+
+	private final PriceAlertRepository priceAlertRepository;
+	private final ProductRepository productRepository;
+	private final UserRepository userRepository;
+
+	/**
+	 * 할인 알림 설정 및 재설정
+	 * 사용자가 상품 상세 화면에서 원하는 할인가를 선택하여 DB에 저장
+	 * 실제 알림 발송은 PriceAlertScheduler가 주기적으로 가격을 확인하여 처리
+	 */
+	@Transactional
+	public PriceAlert createOrUpdatePriceAlert(Long userId, PriceAlertRequest request) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		Product product = productRepository.findById(request.getProductId())
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
+
+		// 기존 활성 건이 있으면 비활성화 (재설정)
+		priceAlertRepository.findByUserIdAndProductIdAndIsActiveTrue(userId, request.getProductId())
+			.ifPresent(PriceAlert::deactivate);
+
+		// 새 건 생성
+		PriceAlert priceAlert = PriceAlert.builder()
+			.targetPrice(request.getTargetPrice())
+			.isActive(true)
+			.user(user)
+			.product(product)
+			.build();
+
+		return priceAlertRepository.save(priceAlert);
+	}
+
+	// 현재 활성 중인 알림 조회
+	@Transactional(readOnly = true)
+	public PriceAlertResponse getPriceAlert(Long userId, Long productId) {
+
+		PriceAlert priceAlert = priceAlertRepository
+			.findByUserIdAndProductIdAndIsActiveTrue(userId, productId)
+			.orElse(null);
+
+		if (priceAlert == null) {
+			return null;
+		}
+
+		return PriceAlertConverter.toResponse(priceAlert);
+	}
+}

--- a/src/main/java/com/ongil/backend/domain/pricealert/service/PriceAlertService.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/service/PriceAlertService.java
@@ -60,11 +60,7 @@ public class PriceAlertService {
 
 		PriceAlert priceAlert = priceAlertRepository
 			.findByUserIdAndProductIdAndIsActiveTrue(userId, productId)
-			.orElse(null);
-
-		if (priceAlert == null) {
-			return null;
-		}
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PRICE_ALERT_NOT_FOUND));
 
 		return PriceAlertConverter.toResponse(priceAlert);
 	}

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -69,6 +69,9 @@ public enum ErrorCode {
 
 	// NOTIFICATION
 	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다.", "NOTI-001"),
+
+	// PRICE_ALERT
+	PRICE_ALERT_NOT_FOUND(HttpStatus.NOT_FOUND, "설정된 가격 알림이 없습니다.", "ALERT-001"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -66,6 +66,9 @@ public enum ErrorCode {
 	// MAGAZINE
 	MAGAZINE_NOT_FOUND(HttpStatus.NOT_FOUND, "매거진을 찾을 수 없습니다.", "MAG-001"),
 	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.", "COMM-002"),
+
+	// NOTIFICATION
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다.", "NOTI-001"),
 	;
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
실시간 알림 구현 

## ✨ 상세 설명
- 할인 알림은 Scheduler + SSE 두 가지를 조합한 구조로 구현되었습니다.
-  사용자가 상품 상세 화면에서 할인 알림을 설정하면 PriceAlert가 DB에 저장되고, PriceAlertScheduler가 30초 간격으로 자동으로 돌면서 현재 상품 가격과 목표 가격을 비교합니다. 조건이 충족되면 세 가지가 순차적으로 실행됩니다. 먼저 PriceAlert의 isNotified를 true로 업데이트하여 중복 알림을 방지하고, Notification을 생성하여 DB에 저장한 후, SSE를 통해 해당 사용자에게 실시간 알림을 전송합니다.
- SSE 연결은 사용자가 웹에 들어오면 자동으로 구독되고, 스케줄러가 조건 충족 시 해당 연결을 통해 알림을 바로 전달합니다. 웹을 닫아 SSE 연결이 끊기는 경우에도 Notification은 DB에 저장되어 있으므로, 다시 웹에 들어오면 읽지 않은 알림에서 확인할 수 있습니다.
- 기타 기능
읽지 않은 알림 목록 조회 및 읽음 처리 API 구현
읽지 않은 알림 개수 조회 API 구현 (뱃지용)
모든 알림 읽음 처리 API 구현
본인의 알림만 읽음 처리 가능하도록 보안 로직 추가

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)
- 가격 알림 버튼 눌렀을 때(현재가는 실시간으로 현재가가 업데이트되서 69000원으로 돼있습니다. )
<img width="1038" height="780" alt="image" src="https://github.com/user-attachments/assets/a334518d-2f89-46f5-812b-ede8edb0ef10" />

- sse 연결 확인과 실시간 메세지 전송 확인 
<img width="1710" height="526" alt="image" src="https://github.com/user-attachments/assets/c4db26e1-ed9b-42a9-836f-90b8ebc07f54" />

- 할인 알림이 잘 오는지 확인 
<img width="1512" height="1100" alt="image" src="https://github.com/user-attachments/assets/8ba0ac8f-aa35-4dfc-abc7-1e3f33d1f007" />

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 실시간 알림 구독 및 수신(SSE) 기능 추가
  * 알림 목록 조회 및 미읽음 개수 확인 기능 추가
  * 알림 읽음 표시 기능 추가 (개별 및 전체 일괄)
  * 상품 가격 알림 설정(생성/수정) 및 조회 기능 추가
  * 자동 가격 모니터링으로 목표 가격 도달 시 실시간 알림 발송
<!-- end of auto-generated comment: release notes by coderabbit.ai -->