### PR TITLE
[Fix] 장바구니 추가 시 검증 추가, 상품 옵션 조회 API 추가

### DIFF
--- a/src/main/java/com/ongil/backend/domain/cart/service/CartService.java
+++ b/src/main/java/com/ongil/backend/domain/cart/service/CartService.java
@@ -14,6 +14,8 @@ import com.ongil.backend.domain.cart.dto.response.CartResponse;
 import com.ongil.backend.domain.cart.entity.Cart;
 import com.ongil.backend.domain.cart.repository.CartRepository;
 import com.ongil.backend.domain.product.entity.Product;
+import com.ongil.backend.domain.product.entity.ProductOption;
+import com.ongil.backend.domain.product.repository.ProductOptionRepository;
 import com.ongil.backend.domain.product.repository.ProductRepository;
 import com.ongil.backend.domain.user.entity.User;
 import com.ongil.backend.domain.user.repository.UserRepository;
@@ -30,6 +32,7 @@ public class CartService {
 
 	private final CartRepository cartRepository;
 	private final ProductRepository productRepository;
+	private final ProductOptionRepository productOptionRepository;
 	private final UserRepository userRepository;
 	private final CartConverter cartConverter;
 
@@ -55,6 +58,16 @@ public class CartService {
 		Product product = productRepository.findWithBrandAndCategoryById(request.productId())
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
 
+		// 옵션 존재 여부 확인
+		ProductOption productOption = productOptionRepository
+			.findByProductIdAndSizeAndColor(
+				request.productId(),
+				request.selectedSize(),
+				request.selectedColor()
+			)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
+
+		// 기존 장바구니 확인
 		Optional<Cart> existingCart = cartRepository
 			.findByUserIdAndProductIdAndSelectedSizeAndSelectedColor(
 				userId,
@@ -63,10 +76,24 @@ public class CartService {
 				request.selectedColor()
 			);
 
+		int totalQuantity = request.quantity();
+
 		if (existingCart.isPresent()) {
 			Cart cart = existingCart.get();
-			cart.updateQuantity(cart.getQuantity() + request.quantity());
+			totalQuantity = cart.getQuantity() + request.quantity();
+
+			// 재고 확인 (기존 수량 + 추가 수량)
+			if (totalQuantity > productOption.getStock()) {
+				throw new ValidationException(ErrorCode.OUT_OF_STOCK);
+			}
+
+			cart.updateQuantity(totalQuantity);
 			return cartConverter.toResponse(cart);
+		}
+
+		// 재고 확인 (신규 추가)
+		if (totalQuantity > productOption.getStock()) {
+			throw new ValidationException(ErrorCode.OUT_OF_STOCK);
 		}
 
 		Cart cart = Cart.builder()
@@ -91,6 +118,27 @@ public class CartService {
 
 		Cart cart = cartRepository.findByIdAndUserId(cartId, userId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.CART_NOT_FOUND));
+
+		// 변경될 옵션 정보
+		String updatedSize = request.selectedSize() != null ? request.selectedSize() : cart.getSelectedSize();
+		String updatedColor = request.selectedColor() != null ? request.selectedColor() : cart.getSelectedColor();
+		Integer updatedQuantity = request.quantity() != null ? request.quantity() : cart.getQuantity();
+
+		// 옵션이 변경되거나 수량이 변경된 경우 재고 확인
+		if (request.selectedSize() != null || request.selectedColor() != null || request.quantity() != null) {
+			ProductOption productOption = productOptionRepository
+				.findByProductIdAndSizeAndColor(
+					cart.getProduct().getId(),
+					updatedSize,
+					updatedColor
+				)
+				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
+
+			// 재고 확인
+			if (updatedQuantity > productOption.getStock()) {
+				throw new ValidationException(ErrorCode.OUT_OF_STOCK);
+			}
+		}
 
 		// 옵션 업데이트
 		if (request.selectedSize() != null) {

--- a/src/main/java/com/ongil/backend/domain/cart/service/CartService.java
+++ b/src/main/java/com/ongil/backend/domain/cart/service/CartService.java
@@ -124,6 +124,10 @@ public class CartService {
 		String updatedColor = request.selectedColor() != null ? request.selectedColor() : cart.getSelectedColor();
 		Integer updatedQuantity = request.quantity() != null ? request.quantity() : cart.getQuantity();
 
+		// 옵션 변경 여부 확인
+		boolean optionChanged = (request.selectedSize() != null && !updatedSize.equals(cart.getSelectedSize()))
+			|| (request.selectedColor() != null && !updatedColor.equals(cart.getSelectedColor()));
+
 		// 옵션이 변경되거나 수량이 변경된 경우 재고 확인
 		if (request.selectedSize() != null || request.selectedColor() != null || request.quantity() != null) {
 			ProductOption productOption = productOptionRepository
@@ -140,7 +144,41 @@ public class CartService {
 			}
 		}
 
-		// 옵션 업데이트
+		// 옵션이 변경된 경우 중복 체크
+		if (optionChanged) {
+			Optional<Cart> duplicateCart = cartRepository
+				.findByUserIdAndProductIdAndSelectedSizeAndSelectedColor(
+					userId,
+					cart.getProduct().getId(),
+					updatedSize,
+					updatedColor
+				);
+
+			if (duplicateCart.isPresent() && !duplicateCart.get().getId().equals(cartId)) {
+				// 중복 항목이 존재하면 수량 합산 후 현재 항목 삭제
+				Cart existingCart = duplicateCart.get();
+				int totalQuantity = existingCart.getQuantity() + updatedQuantity;
+
+				// 합산된 수량이 재고를 초과하는지 확인
+				ProductOption productOption = productOptionRepository
+					.findByProductIdAndSizeAndColor(
+						cart.getProduct().getId(),
+						updatedSize,
+						updatedColor
+					)
+					.orElseThrow(() -> new EntityNotFoundException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
+
+				if (totalQuantity > productOption.getStock()) {
+					throw new ValidationException(ErrorCode.OUT_OF_STOCK);
+				}
+
+				existingCart.updateQuantity(totalQuantity);
+				cartRepository.delete(cart);
+				return cartConverter.toResponse(existingCart);
+			}
+		}
+
+		// 중복이 없으면 옵션 업데이트
 		if (request.selectedSize() != null) {
 			cart.updateSize(request.selectedSize());
 		}

--- a/src/main/java/com/ongil/backend/domain/product/controller/ProductController.java
+++ b/src/main/java/com/ongil/backend/domain/product/controller/ProductController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.ongil.backend.domain.product.dto.request.ProductSearchCondition;
 import com.ongil.backend.domain.product.dto.response.ProductDetailResponse;
+import com.ongil.backend.domain.product.dto.response.ProductOptionResponse;
 import com.ongil.backend.domain.product.dto.response.ProductSearchPageResDto;
 import com.ongil.backend.domain.product.dto.response.ProductSimpleResponse;
 import com.ongil.backend.domain.product.dto.response.RecommendedProductResponse;
@@ -46,6 +47,15 @@ public class ProductController {
 	) {
 		ProductDetailResponse productDetail = productService.getProductDetail(productId, userId);
 		return DataResponse.from(productDetail);
+	}
+
+	@Operation(summary = "상품별 전체 옵션 목록 조회", description = "상품의 색상/사이즈별 옵션과 재고 정보를 조회합니다. 장바구니 추가 시 사용됩니다.")
+	@GetMapping("/{productId}/options")
+	public DataResponse<List<ProductOptionResponse>> getProductOptions(
+		@PathVariable Long productId
+	) {
+		List<ProductOptionResponse> options = productService.getProductOptions(productId);
+		return DataResponse.from(options);
 	}
 
 	@Operation(

--- a/src/main/java/com/ongil/backend/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/ongil/backend/domain/product/converter/ProductConverter.java
@@ -87,7 +87,7 @@ public class ProductConverter {
 	}
 
 	// 옵션 리스트 변환
-	private List<ProductOptionResponse> convertOptions(List<ProductOption> options) {
+	public List<ProductOptionResponse> convertOptions(List<ProductOption> options) {
 		if (options == null || options.isEmpty()) {
 			return Collections.emptyList();
 		}

--- a/src/main/java/com/ongil/backend/domain/product/service/ProductService.java
+++ b/src/main/java/com/ongil/backend/domain/product/service/ProductService.java
@@ -22,6 +22,7 @@ import com.ongil.backend.domain.product.converter.SizeGuideConverter;
 import com.ongil.backend.domain.product.dto.request.ProductSearchCondition;
 import com.ongil.backend.domain.product.dto.response.AiMaterialDescriptionResponse;
 import com.ongil.backend.domain.product.dto.response.ProductDetailResponse;
+import com.ongil.backend.domain.product.dto.response.ProductOptionResponse;
 import com.ongil.backend.domain.product.dto.response.ProductSearchPageResDto;
 import com.ongil.backend.domain.product.dto.response.ProductSimpleResponse;
 import com.ongil.backend.domain.product.dto.response.RecommendedProductResponse;
@@ -90,6 +91,17 @@ public class ProductService {
 		List<ProductOption> options = productOptionRepository.findByProductId(productId);
 
 		return productConverter.toDetailResponse(product, options);
+	}
+
+	// 상품별 옵션 목록 조회
+	public List<ProductOptionResponse> getProductOptions(Long productId) {
+		// 상품 존재 여부 확인
+		if (!productRepository.existsById(productId)) {
+			throw new EntityNotFoundException(ErrorCode.PRODUCT_NOT_FOUND);
+		}
+
+		List<ProductOption> options = productOptionRepository.findByProductId(productId);
+		return productConverter.convertOptions(options);
 	}
 
 	// 상품 조회 기록 저장

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
 
 	// PRODUCT
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다.", "PRODUCT-001"),
+	PRODUCT_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "선택한 옵션(색상/사이즈)을 찾을 수 없습니다.", "PRODUCT-002"),
+	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다.", "PRODUCT-003"),
 
 	// BRAND
 	BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "브랜드를 찾을 수 없습니다.", "BRAND-001"),


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
장바구니 추가 시 검증 추가, 상품 옵션 조회 API 추가

## ✨ 상세 설명
- 장바구니 추가시 없는 색상과 사이즈가 있을시에도 추가가 된다는 프론트의 수정 요청으로 인해서 검증을 추가하였고, 추가적으로 재고 관련 검증도 추가했습니다. 
- 상품 상세 화면에서 해당 상품의 사이즈 or 색상 등의 옵션 리스트를 조회하는 기능이 필요하다는 프론트 요청으로 상품별 옵션 목록 조회 기능을 추가했습니다. 


## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)
상품별 옵션 조회 리스트
<img width="756" height="550" alt="image" src="https://github.com/user-attachments/assets/4073802d-9f1a-45bd-afb7-62ab7cb3d881" />

색상 or 사이즈 검증 로직 테스트 
<img width="756" height="410" alt="image" src="https://github.com/user-attachments/assets/8cce90bc-9560-41dc-a650-2fc0150394b7" />


## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상품 옵션(색상/사이즈) 전체 조회 API 추가 — 제품별 선택 가능한 옵션을 조회할 수 있습니다.

* **버그 수정**
  * 장바구니 추가/수정 시 옵션별 재고 검증 강화 — 재고 부족으로 인한 주문 방지
  * 옵션 변경 시 중복 항목 병합 및 수량 검증 적용
  * 재고/옵션 관련 명확한 오류 코드·메시지 추가 (옵션 미존재, 재고부족)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->