### PR TITLE
 refactor: 홈 화면 통합 API 더미 데이터를 실제 서비스 호출로 변경

### DIFF
--- a/src/main/java/com/ongil/backend/domain/home/controller/HomeController.java
+++ b/src/main/java/com/ongil/backend/domain/home/controller/HomeController.java
@@ -1,6 +1,6 @@
 package com.ongil.backend.domain.home.controller;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "Home", description = "홈 화면 관련 API")
+@Tag(name = "Home", description = "홈 화면 관련 API (토큰 선택 - 로그인 시 개인화 데이터 제공)")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/home")
@@ -22,9 +22,20 @@ public class HomeController {
     private final HomeService homeService;
 
     @GetMapping
-    @Operation(summary = "홈 화면 데이터 조회 API", description = "메인 배너, 추천 상품 등 홈 화면 구성을 위한 데이터를 조회합니다.")
-    public ResponseEntity<DataResponse<HomeResDto>> getHomeData() {
-        HomeResDto res = homeService.getHomeData();
-        return ResponseEntity.ok(DataResponse.from(res));
+    @Operation(
+            summary = "홈 화면 데이터 조회 API",
+            description = """
+                    홈 화면 구성에 필요한 모든 데이터를 한 번에 조회합니다.
+                    - 할인 광고 배너 (5개)
+                    - 추천 상품 목록 (로그인: 개인화 추천 / 비로그인: 인기 상품)
+                    - 추천 브랜드 (랜덤 3개 브랜드 + 각 6개 상품)
+                    - 장바구니 개수 (로그인 시에만, 비로그인 시 null)
+                    """
+    )
+    public DataResponse<HomeResDto> getHomeData(
+            @AuthenticationPrincipal Long userId
+    ) {
+        HomeResDto res = homeService.getHomeData(userId);
+        return DataResponse.from(res);
     }
 }

--- a/src/main/java/com/ongil/backend/domain/home/converter/HomeConverter.java
+++ b/src/main/java/com/ongil/backend/domain/home/converter/HomeConverter.java
@@ -1,19 +1,28 @@
 package com.ongil.backend.domain.home.converter;
 
-import com.ongil.backend.domain.home.dto.response.HomeResDto;
-import lombok.experimental.UtilityClass;
-
 import java.util.List;
+
+import com.ongil.backend.domain.advertisement.dto.AdvertisementResponse;
+import com.ongil.backend.domain.brand.dto.response.BrandRecommendResponse;
+import com.ongil.backend.domain.home.dto.response.HomeResDto;
+import com.ongil.backend.domain.product.dto.response.RecommendedProductResponse;
+
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class HomeConverter {
 
-    // 나중에는 파라미터로 실제 Product, Magazine 객체를 받게 됩니다.
-    public static HomeResDto toHomeResDto(List<String> banners, List<String> products, String magazineTitle) {
+    public static HomeResDto toHomeResDto(
+            List<AdvertisementResponse> advertisements,
+            List<RecommendedProductResponse> recommendedProducts,
+            List<BrandRecommendResponse> recommendBrands,
+            Long cartCount
+    ) {
         return HomeResDto.builder()
-                .bannerUrls(banners)
-                .recommendProducts(products)
-                .latestMagazineTitle(magazineTitle)
+                .advertisements(advertisements)
+                .recommendedProducts(recommendedProducts)
+                .recommendBrands(recommendBrands)
+                .cartCount(cartCount)
                 .build();
     }
 }

--- a/src/main/java/com/ongil/backend/domain/home/dto/response/HomeResDto.java
+++ b/src/main/java/com/ongil/backend/domain/home/dto/response/HomeResDto.java
@@ -1,17 +1,27 @@
 package com.ongil.backend.domain.home.dto.response;
 
 import java.util.List;
+
+import com.ongil.backend.domain.advertisement.dto.AdvertisementResponse;
+import com.ongil.backend.domain.brand.dto.response.BrandRecommendResponse;
+import com.ongil.backend.domain.product.dto.response.RecommendedProductResponse;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "홈 화면 통합 응답")
 public record HomeResDto(
-        @Schema(description = "메인 배너 이미지 URL 리스트")
-        List<String> bannerUrls,
 
-        @Schema(description = "추천 상품 이름 리스트 (예시)")
-        List<String> recommendProducts,
+        @Schema(description = "할인 광고 배너 목록 (5개)")
+        List<AdvertisementResponse> advertisements,
 
-        @Schema(description = "최신 매거진 제목")
-        String latestMagazineTitle
+        @Schema(description = "추천 상품 목록")
+        List<RecommendedProductResponse> recommendedProducts,
+
+        @Schema(description = "추천 브랜드 목록 (3개 브랜드 + 각 6개 상품)")
+        List<BrandRecommendResponse> recommendBrands,
+
+        @Schema(description = "장바구니 담긴 개수 (비로그인 시 null)")
+        Long cartCount
 ) {}

--- a/src/main/java/com/ongil/backend/domain/home/service/HomeService.java
+++ b/src/main/java/com/ongil/backend/domain/home/service/HomeService.java
@@ -1,32 +1,40 @@
 package com.ongil.backend.domain.home.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ongil.backend.domain.advertisement.dto.AdvertisementResponse;
+import com.ongil.backend.domain.advertisement.service.AdvertisementService;
+import com.ongil.backend.domain.brand.dto.response.BrandRecommendResponse;
+import com.ongil.backend.domain.brand.service.BrandService;
+import com.ongil.backend.domain.cart.service.CartService;
 import com.ongil.backend.domain.home.converter.HomeConverter;
 import com.ongil.backend.domain.home.dto.response.HomeResDto;
+import com.ongil.backend.domain.product.dto.response.RecommendedProductResponse;
+import com.ongil.backend.domain.product.service.ProductService;
 
 import lombok.RequiredArgsConstructor;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 조회 전용이므로 readOnly 권장
+@Transactional(readOnly = true)
 public class HomeService {
 
-    // TODO: 나중에 ProductRepository, MagazineRepository 등을 여기에 DI 받습니다.
+    private static final int RECOMMENDED_PRODUCTS_SIZE = 10;
 
-    public HomeResDto getHomeData() {
-        // 1. DB에서 배너 가져오기 (가정)
-        List<String> banners = List.of("https://banner1.com", "https://banner2.com");
+    private final AdvertisementService advertisementService;
+    private final ProductService productService;
+    private final BrandService brandService;
+    private final CartService cartService;
 
-        // 2. DB에서 추천 상품 가져오기 (가정)
-        List<String> products = List.of("온길 시그니처 화분", "유기농 비료 세트");
+    public HomeResDto getHomeData(Long userId) {
+        List<AdvertisementResponse> advertisements = advertisementService.getHomeAdvertisements();
+        List<RecommendedProductResponse> recommendedProducts = productService.getRecommendedProducts(userId, RECOMMENDED_PRODUCTS_SIZE);
+        List<BrandRecommendResponse> recommendBrands = brandService.getRecommendBrands();
+        Long cartCount = (userId != null) ? cartService.getCartCount(userId) : null;
 
-        // 3. DB에서 최신 매거진 가져오기 (가정)
-        String magazineTitle = "겨울철 식물 관리법";
-
-        // 4. Converter를 사용해 DTO로 변환
-        return HomeConverter.toHomeResDto(banners, products, magazineTitle);
+        return HomeConverter.toHomeResDto(advertisements, recommendedProducts, recommendBrands, cartCount);
     }
 }


### PR DESCRIPTION
## 🔍️ 작업 내용
 파일: HomeController.java                        
  변경 내용: @AuthenticationPrincipal Long userId  
  추가
    (로그인/비로그인 분기), 반환 타입              
    ResponseEntity<DataResponse> →                 
    DataResponse로 통일, @Tag에 토큰 선택 설명
    추가
  ────────────────────────────────────────
  파일: HomeService.java
  변경 내용: 더미 데이터 제거 →
  AdvertisementService,
    ProductService, BrandService, CartService
    4개 서비스 호출하여 실제 데이터 조합
  ────────────────────────────────────────
  파일: HomeResDto.java
  변경 내용: 문자열 필드 → 실제 응답 DTO 타입으로
  변경
    (AdvertisementResponse,
    RecommendedProductResponse,
    BrandRecommendResponse, Long cartCount)
  ────────────────────────────────────────
  파일: HomeConverter.java
  변경 내용: 기존 문자열 변환 로직 → 실제 DTO 조합
  변환
    로직으로 재작성
  요약

  GET /api/home 하나로 홈 화면에 필요한 광고 5개 +
  추천 상품 + 추천 브랜드 3개 + 장바구니 개수를 한
  번에 반환하도록 리팩토링

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 홈 화면이 로그인 시 개인화 데이터를 제공하도록 개선되었습니다.
  * 할인 광고 배너(5개), 추천 상품, 추천 브랜드(3개 브랜드 + 각 6개 상품)가 통합되어 표시됩니다.
  * 로그인 사용자는 홈 화면에서 장바구니 담긴 개수를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->