### PR TITLE
feat: 주문 취소/배송지 변경 API 구현 및 HTTPS 도메인2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,11 @@ services:
     image: nginx:alpine
     container_name: ongil-nginx
     ports:
-      - "80:80"
+      - "80:80"   # HTTP (암호화 안 됨)
+      - "443:443"  # HTTPS (암호화됨, SSL/TLS)
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
       - backend
     restart: always

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,16 +1,79 @@
-server {
-    listen 80;
-    server_name _;
+events {
+    worker_connections 1024;
+}
 
-    location / {
-        proxy_pass http://ongil-backend:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
 
-        proxy_connect_timeout 60;
-        proxy_send_timeout 300;
-        proxy_read_timeout 300;
+    # HTTP → HTTPS 리다이렉트(강제 이동)
+    server {
+        listen 80;
+        server_name ongil.shop www.ongil.shop;
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    # HTTPS 서버 및 인증서 설정
+    server {
+        listen 443 ssl;
+        server_name ongil.shop www.ongil.shop;
+
+				# 아까 Certbot으로 발급받은 '신분증'과 '비밀키' 위치
+        ssl_certificate /etc/letsencrypt/live/ongil.shop/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/ongil.shop/privkey.pem;
+
+        # 백엔드 API
+        location /api/ {
+		        # [중요] Docker 컨테이너 이름(ongil-backend)으로 통신
+            proxy_pass http://ongil-backend:8080/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60;
+            proxy_send_timeout 300;
+            proxy_read_timeout 300;
+        }
+
+        # Swagger UI - 정확한 경로 리다이렉트
+        location = /swagger-ui/ {
+            return 301 https://$host/swagger-ui/index.html;
+        }
+
+				# Swagger가 필요로 하는 CSS, JS 파일 등을 백엔드에서 가져옴
+        location = /swagger-ui {
+            return 301 https://$host/swagger-ui/index.html;
+        }
+
+        # Swagger UI 리소스 (CSS, JS 등)
+        location /swagger-ui/ {
+            proxy_pass http://ongil-backend:8080/swagger-ui/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # API Docs
+        location /v3/api-docs {
+            proxy_pass http://ongil-backend:8080/v3/api-docs;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location /v3/ {
+            proxy_pass http://ongil-backend:8080/v3/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # 프론트엔드 (임시 기본 페이지)
+        location / {
+            root /usr/share/nginx/html;
+            try_files $uri /index.html;
+        }
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,7 +28,7 @@ http {
         # 백엔드 API
         location /api/ {
 		        # [중요] Docker 컨테이너 이름(ongil-backend)으로 통신
-            proxy_pass http://ongil-backend:8080/;
+            proxy_pass http://ongil-backend:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -73,7 +73,7 @@ http {
         # 프론트엔드 (임시 기본 페이지)
         location / {
             root /usr/share/nginx/html;
-            try_files $uri /index.html;
+            try_files $uri $uri/ /index.html;
         }
     }
 }

--- a/src/main/java/com/ongil/backend/domain/address/controller/AddressController.java
+++ b/src/main/java/com/ongil/backend/domain/address/controller/AddressController.java
@@ -11,9 +11,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ongil.backend.domain.address.dto.request.ShippingInfoCreateReqDto;
 import com.ongil.backend.domain.address.dto.request.ShippingInfoUpdateReqDto;
+import com.ongil.backend.domain.address.dto.response.AddressListResponse;
 import com.ongil.backend.domain.address.dto.response.ShippingInfoResDto;
 import com.ongil.backend.domain.address.service.AddressService;
 import com.ongil.backend.global.common.dto.DataResponse;
+
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,6 +30,14 @@ import lombok.RequiredArgsConstructor;
 public class AddressController {
 
 	private final AddressService addressService;
+
+	@GetMapping
+	@Operation(summary = "내 배송지 목록 조회", description = "현재 로그인한 사용자의 전체 배송지 목록을 조회합니다. 토큰 필요")
+	public DataResponse<List<AddressListResponse>> getAddressList(
+		@AuthenticationPrincipal Long userId
+	) {
+		return DataResponse.from(addressService.getAddressList(userId));
+	}
 
 	@GetMapping("/me")
 	@Operation(summary = "내 배송지 조회", description = "현재 로그인한 사용자의 배송지 정보를 조회합니다.")

--- a/src/main/java/com/ongil/backend/domain/address/dto/response/AddressListResponse.java
+++ b/src/main/java/com/ongil/backend/domain/address/dto/response/AddressListResponse.java
@@ -1,0 +1,29 @@
+package com.ongil.backend.domain.address.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "배송지 목록 항목")
+public record AddressListResponse(
+
+	@Schema(description = "배송지 ID")
+	Long addressId,
+
+	@Schema(description = "수령인 이름")
+	String recipientName,
+
+	@Schema(description = "수령인 연락처")
+	String recipientPhone,
+
+	@Schema(description = "기본 주소")
+	String baseAddress,
+
+	@Schema(description = "상세 주소")
+	String detailAddress,
+
+	@Schema(description = "우편번호")
+	String postalCode,
+
+	@Schema(description = "기본 배송지 여부")
+	boolean isDefault
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/address/repository/AddressRepository.java
+++ b/src/main/java/com/ongil/backend/domain/address/repository/AddressRepository.java
@@ -1,5 +1,6 @@
 package com.ongil.backend.domain.address.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,8 @@ import com.ongil.backend.domain.address.entity.Address;
 public interface AddressRepository extends JpaRepository<Address, Long> {
 
 	Optional<Address> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+
+	List<Address> findAllByUserIdOrderByIsDefaultDescCreatedAtDesc(Long userId);
 
 	void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ongil/backend/domain/address/service/AddressService.java
+++ b/src/main/java/com/ongil/backend/domain/address/service/AddressService.java
@@ -1,5 +1,6 @@
 package com.ongil.backend.domain.address.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -8,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ongil.backend.domain.address.converter.AddressConverter;
 import com.ongil.backend.domain.address.dto.request.ShippingInfoCreateReqDto;
 import com.ongil.backend.domain.address.dto.request.ShippingInfoUpdateReqDto;
+import com.ongil.backend.domain.address.dto.response.AddressListResponse;
 import com.ongil.backend.domain.address.dto.response.ShippingInfoResDto;
 import com.ongil.backend.domain.address.entity.Address;
 import com.ongil.backend.domain.address.repository.AddressRepository;
@@ -26,6 +28,22 @@ public class AddressService {
 
 	private final AddressRepository addressRepository;
 	private final UserRepository userRepository;
+
+	public List<AddressListResponse> getAddressList(Long userId) {
+		List<Address> addresses = addressRepository.findAllByUserIdOrderByIsDefaultDescCreatedAtDesc(userId);
+
+		return addresses.stream()
+			.map(address -> new AddressListResponse(
+				address.getId(),
+				address.getRecipientName(),
+				address.getRecipientPhone(),
+				address.getBaseAddress(),
+				address.getDetailAddress(),
+				address.getPostalCode(),
+				address.isDefault()
+			))
+			.toList();
+	}
 
 	public ShippingInfoResDto getShippingInfo(Long userId) {
 		Optional<Address> address = addressRepository.findFirstByUserIdOrderByCreatedAtDesc(userId);

--- a/src/main/java/com/ongil/backend/domain/order/controller/OrderController.java
+++ b/src/main/java/com/ongil/backend/domain/order/controller/OrderController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,8 +16,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ongil.backend.domain.order.dto.request.CancelRefundInfoRequest;
 import com.ongil.backend.domain.order.dto.request.CartOrderRequest;
+import com.ongil.backend.domain.order.dto.request.DeliveryAddressUpdateRequest;
+import com.ongil.backend.domain.order.dto.request.OrderCancelRequest;
 import com.ongil.backend.domain.order.dto.request.OrderCreateRequest;
+import com.ongil.backend.domain.order.dto.response.CancelRefundInfoResponse;
+import com.ongil.backend.domain.order.dto.response.OrderCancelResponse;
 import com.ongil.backend.domain.order.dto.response.OrderDetailResponse;
 import com.ongil.backend.domain.order.dto.response.OrderHistoryResponse;
 import com.ongil.backend.domain.order.service.OrderService;
@@ -106,6 +112,45 @@ public class OrderController {
 		@AuthenticationPrincipal Long userId, @PathVariable Long orderId
 	) {
 		return DataResponse.from(orderService.getOrderDetail(userId, orderId));
+	}
+
+	@GetMapping("/{orderId}/cancel/refund-info")
+	@Operation(
+		summary = "환불 정보 조회",
+		description = "주문 취소 시 환불 정보를 조회합니다. 주문 접수 상태에서만 조회 가능합니다. 토큰 필요"
+	)
+	public DataResponse<CancelRefundInfoResponse> getRefundInfo(
+		@AuthenticationPrincipal Long userId, @PathVariable Long orderId
+	) {
+		return DataResponse.from(orderService.getRefundInfo(userId, orderId));
+	}
+
+	@PostMapping("/{orderId}/cancel")
+	@Operation(
+		summary = "주문 취소",
+		description = "주문을 취소합니다. 주문 접수 상태에서만 취소 가능합니다. " +
+			"addToCart가 true이면 취소된 상품을 장바구니에 다시 담습니다. 토큰 필요"
+	)
+	public DataResponse<OrderCancelResponse> cancelOrder(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long orderId,
+		@RequestBody @Valid OrderCancelRequest request
+	) {
+		return DataResponse.from(orderService.cancelOrder(userId, orderId, request));
+	}
+
+	@PatchMapping("/{orderId}/delivery-address")
+	@Operation(
+		summary = "주문 배송지 변경",
+		description = "주문의 배송지를 사용자의 기존 등록 배송지 중 하나로 변경합니다. " +
+			"주문 접수 상태에서만 변경 가능합니다. 토큰 필요"
+	)
+	public DataResponse<OrderDetailResponse> updateDeliveryAddress(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long orderId,
+		@RequestBody @Valid DeliveryAddressUpdateRequest request
+	) {
+		return DataResponse.from(orderService.updateDeliveryAddress(userId, orderId, request));
 	}
 
 }

--- a/src/main/java/com/ongil/backend/domain/order/converter/OrderConverter.java
+++ b/src/main/java/com/ongil/backend/domain/order/converter/OrderConverter.java
@@ -13,11 +13,13 @@ import com.ongil.backend.domain.cart.entity.Cart;
 import com.ongil.backend.domain.order.dto.request.CartOrderRequest;
 import com.ongil.backend.domain.order.dto.request.OrderCreateRequest;
 import com.ongil.backend.domain.order.dto.request.OrderItemRequest;
+import com.ongil.backend.domain.order.dto.response.OrderCancelResponse;
 import com.ongil.backend.domain.order.dto.response.OrderDetailResponse;
 import com.ongil.backend.domain.order.dto.response.OrderHistoryResponse;
 import com.ongil.backend.domain.order.dto.response.OrderItemDto;
 import com.ongil.backend.domain.order.dto.response.OrderItemSummaryDto;
 import com.ongil.backend.domain.order.dto.response.OrderSummaryDto;
+import com.ongil.backend.domain.order.dto.response.RefundInfoDto;
 import com.ongil.backend.domain.order.entity.Order;
 import com.ongil.backend.domain.order.entity.OrderItem;
 import com.ongil.backend.domain.order.enums.OrderStatus;
@@ -93,6 +95,55 @@ public class OrderConverter {
 			request.detailAddress(),
 			request.postalCode(),
 			request.deliveryMessage()
+		);
+	}
+
+	// OrderItem -> OrderItemDto
+	public OrderItemDto toOrderItemDto(OrderItem orderItem) {
+		Product product = orderItem.getProduct();
+
+		String imageUrl = "default-image-url";
+		if (product.getImageUrls() != null && !product.getImageUrls().isBlank()) {
+			imageUrl = product.getImageUrls().split(",")[0].trim();
+		}
+
+		String brandName = product.getBrand() != null ? product.getBrand().getName() : "일반 브랜드";
+
+		return new OrderItemDto(
+			product.getId(),
+			brandName,
+			product.getName(),
+			imageUrl,
+			orderItem.getSelectedSize(),
+			orderItem.getSelectedColor(),
+			orderItem.getQuantity(),
+			orderItem.getPriceAtOrder()
+		);
+	}
+
+	// Order의 OrderItem 리스트 -> OrderItemDto 리스트
+	public List<OrderItemDto> toOrderItemDtos(Order order) {
+		return order.getOrderItems().stream()
+			.map(this::toOrderItemDto)
+			.toList();
+	}
+
+	// Order -> OrderCancelResponse
+	public OrderCancelResponse toCancelResponse(Order order, List<OrderItemDto> itemDtos, RefundInfoDto refundInfo) {
+		return new OrderCancelResponse(
+			order.getId(),
+			order.getOrderNumber(),
+			order.getOrderStatus(),
+			order.getCanceledAt(),
+			order.getCancelReason(),
+			order.getCancelDetail(),
+			itemDtos,
+			refundInfo,
+			order.getDeliveryAddress() + " " + (order.getDetailAddress() != null ? order.getDetailAddress() : ""),
+			order.getRecipient(),
+			order.getRecipientPhone(),
+			order.getDeliveryMessage(),
+			order.getCreatedAt()
 		);
 	}
 

--- a/src/main/java/com/ongil/backend/domain/order/converter/OrderConverter.java
+++ b/src/main/java/com/ongil/backend/domain/order/converter/OrderConverter.java
@@ -69,7 +69,7 @@ public class OrderConverter {
 			order.getTotalAmount(),
 			order.getRecipient(),
 			order.getRecipientPhone(),
-			order.getDeliveryAddress() + " " + (order.getDetailAddress() != null ? order.getDetailAddress() : ""),
+			order.getDeliveryAddress() + (order.getDetailAddress() != null ? " " + order.getDetailAddress() : ""),
 			order.getDeliveryMessage(),
 			order.getCreatedAt()
 		);
@@ -134,12 +134,13 @@ public class OrderConverter {
 			order.getId(),
 			order.getOrderNumber(),
 			order.getOrderStatus(),
+			order.getTotalAmount(),
 			order.getCanceledAt(),
 			order.getCancelReason(),
 			order.getCancelDetail(),
 			itemDtos,
 			refundInfo,
-			order.getDeliveryAddress() + " " + (order.getDetailAddress() != null ? order.getDetailAddress() : ""),
+			order.getDeliveryAddress() + (order.getDetailAddress() != null ? " " + order.getDetailAddress() : ""),
 			order.getRecipient(),
 			order.getRecipientPhone(),
 			order.getDeliveryMessage(),

--- a/src/main/java/com/ongil/backend/domain/order/dto/request/CancelRefundInfoRequest.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/request/CancelRefundInfoRequest.java
@@ -1,0 +1,20 @@
+package com.ongil.backend.domain.order.dto.request;
+
+import com.ongil.backend.domain.order.enums.CancelReason;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "환불 정보 조회 요청")
+public record CancelRefundInfoRequest(
+
+	@Schema(description = "취소 사유")
+	@NotNull(message = "취소 사유는 필수입니다")
+	CancelReason cancelReason,
+
+	@Schema(description = "상세 취소 사유 (1~300자)")
+	@Size(min = 1, max = 300, message = "상세 사유는 1자 이상 300자 이하로 입력해주세요")
+	String cancelDetail
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/order/dto/request/DeliveryAddressUpdateRequest.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/request/DeliveryAddressUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.ongil.backend.domain.order.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "주문 배송지 변경 요청")
+public record DeliveryAddressUpdateRequest(
+
+	@Schema(description = "변경할 배송지 ID")
+	@NotNull(message = "배송지 ID는 필수입니다")
+	Long addressId
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/order/dto/request/OrderCancelRequest.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/request/OrderCancelRequest.java
@@ -1,0 +1,24 @@
+package com.ongil.backend.domain.order.dto.request;
+
+import com.ongil.backend.domain.order.enums.CancelReason;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "주문 취소 요청")
+public record OrderCancelRequest(
+
+	@Schema(description = "취소 사유")
+	@NotNull(message = "취소 사유는 필수입니다")
+	CancelReason cancelReason,
+
+	@Schema(description = "상세 취소 사유 (1~300자)")
+	@Size(min = 1, max = 300, message = "상세 사유는 1자 이상 300자 이하로 입력해주세요")
+	String cancelDetail,
+
+	@Schema(description = "취소 상품 장바구니에 다시 담기 여부")
+	@NotNull(message = "장바구니 담기 여부는 필수입니다")
+	Boolean addToCart
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/order/dto/response/CancelRefundInfoResponse.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/response/CancelRefundInfoResponse.java
@@ -1,0 +1,16 @@
+package com.ongil.backend.domain.order.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "환불 정보 조회 응답")
+public record CancelRefundInfoResponse(
+
+	@Schema(description = "주문 상품 목록")
+	List<OrderItemDto> orderItems,
+
+	@Schema(description = "환불 정보")
+	RefundInfoDto refundInfo
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/order/dto/response/OrderCancelResponse.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/response/OrderCancelResponse.java
@@ -20,6 +20,9 @@ public record OrderCancelResponse(
 	@Schema(description = "주문 상태")
 	OrderStatus orderStatus,
 
+	@Schema(description = "주문 총액")
+	Integer totalAmount,
+
 	@Schema(description = "취소 일시")
 	LocalDateTime canceledAt,
 

--- a/src/main/java/com/ongil/backend/domain/order/dto/response/OrderCancelResponse.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/response/OrderCancelResponse.java
@@ -1,0 +1,53 @@
+package com.ongil.backend.domain.order.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.ongil.backend.domain.order.enums.CancelReason;
+import com.ongil.backend.domain.order.enums.OrderStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주문 취소 완료 응답")
+public record OrderCancelResponse(
+
+	@Schema(description = "주문 ID")
+	Long orderId,
+
+	@Schema(description = "주문 번호")
+	String orderNumber,
+
+	@Schema(description = "주문 상태")
+	OrderStatus orderStatus,
+
+	@Schema(description = "취소 일시")
+	LocalDateTime canceledAt,
+
+	@Schema(description = "취소 사유")
+	CancelReason cancelReason,
+
+	@Schema(description = "취소 상세 사유")
+	String cancelDetail,
+
+	@Schema(description = "주문 상품 목록")
+	List<OrderItemDto> orderItems,
+
+	@Schema(description = "환불 정보")
+	RefundInfoDto refundInfo,
+
+	@Schema(description = "배송 주소")
+	String deliveryAddress,
+
+	@Schema(description = "수령인")
+	String recipient,
+
+	@Schema(description = "수령인 연락처")
+	String recipientPhone,
+
+	@Schema(description = "배송 메시지")
+	String deliveryMessage,
+
+	@Schema(description = "주문 일시")
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/order/dto/response/RefundInfoDto.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/response/RefundInfoDto.java
@@ -11,7 +11,7 @@ public record RefundInfoDto(
 	@Schema(description = "배송비")
 	Integer shippingFee,
 
-	@Schema(description = "반품비 (상품 금액 - 배송비)")
-	Integer returnFee
+	@Schema(description = "환불 금액 (상품 금액 - 배송비)")
+	Integer refundAmount
 ) {
 }

--- a/src/main/java/com/ongil/backend/domain/order/dto/response/RefundInfoDto.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/response/RefundInfoDto.java
@@ -11,7 +11,10 @@ public record RefundInfoDto(
 	@Schema(description = "배송비")
 	Integer shippingFee,
 
-	@Schema(description = "환불 금액 (상품 금액 - 배송비)")
+	@Schema(description = "사용 포인트 (복원 예정)")
+	Integer usedPoints,
+
+	@Schema(description = "환불 금액 (실결제 금액 기준)")
 	Integer refundAmount
 ) {
 }

--- a/src/main/java/com/ongil/backend/domain/order/dto/response/RefundInfoDto.java
+++ b/src/main/java/com/ongil/backend/domain/order/dto/response/RefundInfoDto.java
@@ -1,0 +1,17 @@
+package com.ongil.backend.domain.order.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "환불 정보")
+public record RefundInfoDto(
+
+	@Schema(description = "상품 금액")
+	Integer productAmount,
+
+	@Schema(description = "배송비")
+	Integer shippingFee,
+
+	@Schema(description = "반품비 (상품 금액 - 배송비)")
+	Integer returnFee
+) {
+}

--- a/src/main/java/com/ongil/backend/domain/order/entity/Order.java
+++ b/src/main/java/com/ongil/backend/domain/order/entity/Order.java
@@ -101,11 +101,12 @@ public class Order extends BaseEntity {
 	}
 
 	public void updateDeliveryAddress(String recipient, String recipientPhone,
-		String deliveryAddress, String detailAddress, String postalCode) {
+		String deliveryAddress, String detailAddress, String postalCode, String deliveryMessage) {
 		this.recipient = recipient;
 		this.recipientPhone = recipientPhone;
 		this.deliveryAddress = deliveryAddress;
 		this.detailAddress = detailAddress;
 		this.postalCode = postalCode;
+		this.deliveryMessage = deliveryMessage;
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/order/entity/Order.java
+++ b/src/main/java/com/ongil/backend/domain/order/entity/Order.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.ongil.backend.domain.order.enums.CancelReason;
 import com.ongil.backend.domain.order.enums.OrderStatus;
 import com.ongil.backend.domain.payment.entity.Payment;
 import com.ongil.backend.domain.user.entity.User;
@@ -69,6 +70,13 @@ public class Order extends BaseEntity {
 	@Column(name = "canceled_at")
 	private LocalDateTime canceledAt;
 
+	@Enumerated(EnumType.STRING)
+	@Column(name = "cancel_reason")
+	private CancelReason cancelReason;
+
+	@Column(name = "cancel_detail", length = 300)
+	private String cancelDetail;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
@@ -83,5 +91,21 @@ public class Order extends BaseEntity {
 	public void addOrderItem(OrderItem orderItem) {
 		this.orderItems.add(orderItem);
 		orderItem.setOrder(this);
+	}
+
+	public void cancel(CancelReason cancelReason, String cancelDetail) {
+		this.orderStatus = OrderStatus.CANCELED;
+		this.canceledAt = LocalDateTime.now();
+		this.cancelReason = cancelReason;
+		this.cancelDetail = cancelDetail;
+	}
+
+	public void updateDeliveryAddress(String recipient, String recipientPhone,
+		String deliveryAddress, String detailAddress, String postalCode) {
+		this.recipient = recipient;
+		this.recipientPhone = recipientPhone;
+		this.deliveryAddress = deliveryAddress;
+		this.detailAddress = detailAddress;
+		this.postalCode = postalCode;
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/order/enums/CancelReason.java
+++ b/src/main/java/com/ongil/backend/domain/order/enums/CancelReason.java
@@ -1,0 +1,14 @@
+package com.ongil.backend.domain.order.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CancelReason {
+	WRONG_ADDRESS("배송지 잘못 입력했어요"),
+	SELLER_RESPONSIBILITY("판매자 책임"),
+	BUYER_RESPONSIBILITY("구매자 책임");
+
+	private final String description;
+}

--- a/src/main/java/com/ongil/backend/domain/order/service/OrderService.java
+++ b/src/main/java/com/ongil/backend/domain/order/service/OrderService.java
@@ -217,7 +217,8 @@ public class OrderService {
 			address.getRecipientPhone(),
 			address.getBaseAddress(),
 			address.getDetailAddress(),
-			address.getPostalCode()
+			address.getPostalCode(),
+			address.getDeliveryRequest()
 		);
 
 		List<OrderItemDto> itemDtos = orderConverter.toOrderItemDtos(order);
@@ -249,9 +250,16 @@ public class OrderService {
 			.mapToInt(item -> item.getPriceAtOrder() * item.getQuantity())
 			.sum();
 		int shippingFee = 0;
-		int refundAmount = Math.max(productAmount - shippingFee, 0);
 
-		return new RefundInfoDto(productAmount, shippingFee, refundAmount);
+		int usedPoints = 0;
+		Payment payment = order.getPayment();
+		if (payment != null && payment.getUsedPoints() != null) {
+			usedPoints = payment.getUsedPoints();
+		}
+
+		int refundAmount = Math.max(productAmount - shippingFee - usedPoints, 0);
+
+		return new RefundInfoDto(productAmount, shippingFee, usedPoints, refundAmount);
 	}
 
 	public OrderHistoryResponse getOrderHistory(

--- a/src/main/java/com/ongil/backend/domain/order/service/OrderService.java
+++ b/src/main/java/com/ongil/backend/domain/order/service/OrderService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,7 +46,9 @@ import com.ongil.backend.global.common.exception.EntityNotFoundException;
 import com.ongil.backend.global.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -160,11 +163,19 @@ public class OrderService {
 
 		// 4. 재고 복원
 		for (OrderItem orderItem : order.getOrderItems()) {
-			productOptionRepository.findByProductIdAndSizeAndColor(
+			Optional<ProductOption> optionOpt = productOptionRepository.findByProductIdAndSizeAndColor(
 				orderItem.getProduct().getId(),
 				orderItem.getSelectedSize(),
 				orderItem.getSelectedColor()
-			).ifPresent(option -> option.restoreStock(orderItem.getQuantity()));
+			);
+			if (optionOpt.isPresent()) {
+				optionOpt.get().restoreStock(orderItem.getQuantity());
+			} else {
+				log.warn("재고 복원 실패 - productId: {}, size: {}, color: {}",
+					orderItem.getProduct().getId(),
+					orderItem.getSelectedSize(),
+					orderItem.getSelectedColor());
+			}
 		}
 
 		// 5. 장바구니 담기 (선택)
@@ -191,7 +202,7 @@ public class OrderService {
 		Order order = getOrderAndValidateOwner(userId, orderId);
 
 		if (order.getOrderStatus() != OrderStatus.ORDER_RECEIVED) {
-			throw new AppException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+			throw new AppException(ErrorCode.ORDER_UPDATE_NOT_ALLOWED);
 		}
 
 		Address address = addressRepository.findById(request.addressId())
@@ -238,9 +249,9 @@ public class OrderService {
 			.mapToInt(item -> item.getPriceAtOrder() * item.getQuantity())
 			.sum();
 		int shippingFee = 0;
-		int returnFee = Math.max(productAmount - shippingFee, 0);
+		int refundAmount = Math.max(productAmount - shippingFee, 0);
 
-		return new RefundInfoDto(productAmount, shippingFee, returnFee);
+		return new RefundInfoDto(productAmount, shippingFee, refundAmount);
 	}
 
 	public OrderHistoryResponse getOrderHistory(

--- a/src/main/java/com/ongil/backend/domain/order/service/OrderService.java
+++ b/src/main/java/com/ongil/backend/domain/order/service/OrderService.java
@@ -11,19 +11,32 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ongil.backend.domain.address.entity.Address;
+import com.ongil.backend.domain.address.repository.AddressRepository;
+import com.ongil.backend.domain.cart.dto.request.CartCreateRequest;
 import com.ongil.backend.domain.cart.entity.Cart;
 import com.ongil.backend.domain.cart.repository.CartRepository;
+import com.ongil.backend.domain.cart.service.CartService;
 import com.ongil.backend.domain.order.converter.OrderConverter;
 import com.ongil.backend.domain.order.dto.request.CartOrderRequest;
+import com.ongil.backend.domain.order.dto.request.DeliveryAddressUpdateRequest;
+import com.ongil.backend.domain.order.dto.request.OrderCancelRequest;
 import com.ongil.backend.domain.order.dto.request.OrderCreateRequest;
 import com.ongil.backend.domain.order.dto.request.OrderItemRequest;
+import com.ongil.backend.domain.order.dto.response.CancelRefundInfoResponse;
+import com.ongil.backend.domain.order.dto.response.OrderCancelResponse;
 import com.ongil.backend.domain.order.dto.response.OrderDetailResponse;
 import com.ongil.backend.domain.order.dto.response.OrderHistoryResponse;
 import com.ongil.backend.domain.order.dto.response.OrderItemDto;
+import com.ongil.backend.domain.order.dto.response.RefundInfoDto;
 import com.ongil.backend.domain.order.entity.Order;
 import com.ongil.backend.domain.order.entity.OrderItem;
+import com.ongil.backend.domain.order.enums.OrderStatus;
 import com.ongil.backend.domain.order.repository.OrderRepository;
+import com.ongil.backend.domain.payment.entity.Payment;
 import com.ongil.backend.domain.product.entity.Product;
+import com.ongil.backend.domain.product.entity.ProductOption;
+import com.ongil.backend.domain.product.repository.ProductOptionRepository;
 import com.ongil.backend.domain.product.repository.ProductRepository;
 import com.ongil.backend.domain.user.entity.User;
 import com.ongil.backend.domain.user.repository.UserRepository;
@@ -43,6 +56,9 @@ public class OrderService {
 	private final ProductRepository productRepository;
 	private final OrderConverter orderConverter;
 	private final CartRepository cartRepository;
+	private final CartService cartService;
+	private final AddressRepository addressRepository;
+	private final ProductOptionRepository productOptionRepository;
 
 	@Transactional
 	public Long processPayment(Long userId, OrderCreateRequest request) {
@@ -86,27 +102,7 @@ public class OrderService {
 			throw new AppException(ErrorCode.FORBIDDEN);
 		}
 
-		List<OrderItemDto> itemDtos = order.getOrderItems().stream()
-			.map(item -> {
-				Product product = item.getProduct();
-
-				String firstImageUrl = "default-image-url";
-				if (product.getImageUrls() != null && !product.getImageUrls().isBlank()) {
-					firstImageUrl = product.getImageUrls().split(",")[0].trim();
-				}
-
-				return new OrderItemDto(
-					product.getId(),
-					product.getBrand() != null ? product.getBrand().getName() : "일반 브랜드",
-					product.getName(),
-					firstImageUrl,
-					item.getSelectedSize(),
-					item.getSelectedColor(),
-					item.getQuantity(),
-					item.getPriceAtOrder()
-				);
-			})
-			.toList();
+		List<OrderItemDto> itemDtos = orderConverter.toOrderItemDtos(order);
 
 		return orderConverter.toDetailResponse(order, itemDtos);
 	}
@@ -131,6 +127,120 @@ public class OrderService {
 		cartRepository.deleteAllInBatch(cartItems);
 
 		return orderId;
+	}
+
+	public CancelRefundInfoResponse getRefundInfo(Long userId, Long orderId) {
+		Order order = getOrderAndValidateOwner(userId, orderId);
+		validateCancelable(order);
+
+		List<OrderItemDto> itemDtos = orderConverter.toOrderItemDtos(order);
+		RefundInfoDto refundInfo = calculateRefundInfo(order);
+
+		return new CancelRefundInfoResponse(itemDtos, refundInfo);
+	}
+
+	@Transactional
+	public OrderCancelResponse cancelOrder(Long userId, Long orderId, OrderCancelRequest request) {
+		Order order = getOrderAndValidateOwner(userId, orderId);
+		validateCancelable(order);
+
+		// 1. 주문 취소 처리
+		order.cancel(request.cancelReason(), request.cancelDetail());
+
+		// 2. 결제 취소 처리
+		Payment payment = order.getPayment();
+		if (payment != null) {
+			payment.cancelPayment();
+
+			// 3. 포인트 복원
+			if (payment.getUsedPoints() != null && payment.getUsedPoints() > 0) {
+				order.getUser().restorePoints(payment.getUsedPoints());
+			}
+		}
+
+		// 4. 재고 복원
+		for (OrderItem orderItem : order.getOrderItems()) {
+			productOptionRepository.findByProductIdAndSizeAndColor(
+				orderItem.getProduct().getId(),
+				orderItem.getSelectedSize(),
+				orderItem.getSelectedColor()
+			).ifPresent(option -> option.restoreStock(orderItem.getQuantity()));
+		}
+
+		// 5. 장바구니 담기 (선택)
+		if (Boolean.TRUE.equals(request.addToCart())) {
+			for (OrderItem orderItem : order.getOrderItems()) {
+				CartCreateRequest cartRequest = new CartCreateRequest(
+					orderItem.getProduct().getId(),
+					orderItem.getSelectedSize(),
+					orderItem.getSelectedColor(),
+					orderItem.getQuantity()
+				);
+				cartService.addCart(userId, cartRequest);
+			}
+		}
+
+		List<OrderItemDto> itemDtos = orderConverter.toOrderItemDtos(order);
+		RefundInfoDto refundInfo = calculateRefundInfo(order);
+
+		return orderConverter.toCancelResponse(order, itemDtos, refundInfo);
+	}
+
+	@Transactional
+	public OrderDetailResponse updateDeliveryAddress(Long userId, Long orderId, DeliveryAddressUpdateRequest request) {
+		Order order = getOrderAndValidateOwner(userId, orderId);
+
+		if (order.getOrderStatus() != OrderStatus.ORDER_RECEIVED) {
+			throw new AppException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+		}
+
+		Address address = addressRepository.findById(request.addressId())
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.ADDRESS_NOT_FOUND));
+
+		if (!address.getUser().getId().equals(userId)) {
+			throw new AppException(ErrorCode.ADDRESS_FORBIDDEN);
+		}
+
+		order.updateDeliveryAddress(
+			address.getRecipientName(),
+			address.getRecipientPhone(),
+			address.getBaseAddress(),
+			address.getDetailAddress(),
+			address.getPostalCode()
+		);
+
+		List<OrderItemDto> itemDtos = orderConverter.toOrderItemDtos(order);
+		return orderConverter.toDetailResponse(order, itemDtos);
+	}
+
+	private Order getOrderAndValidateOwner(Long userId, Long orderId) {
+		Order order = orderRepository.findById(orderId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.ORDER_NOT_FOUND));
+
+		if (!order.getUser().getId().equals(userId)) {
+			throw new AppException(ErrorCode.FORBIDDEN);
+		}
+
+		return order;
+	}
+
+	private void validateCancelable(Order order) {
+		if (order.getOrderStatus() == OrderStatus.CANCELED) {
+			throw new AppException(ErrorCode.ORDER_ALREADY_CANCELED);
+		}
+		if (order.getOrderStatus() != OrderStatus.ORDER_RECEIVED) {
+			throw new AppException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+		}
+	}
+
+	private RefundInfoDto calculateRefundInfo(Order order) {
+		int productAmount = order.getOrderItems().stream()
+			.mapToInt(item -> item.getPriceAtOrder() * item.getQuantity())
+			.sum();
+		int shippingFee = 0;
+		int returnFee = Math.max(productAmount - shippingFee, 0);
+
+		return new RefundInfoDto(productAmount, shippingFee, returnFee);
 	}
 
 	public OrderHistoryResponse getOrderHistory(

--- a/src/main/java/com/ongil/backend/domain/payment/entity/Payment.java
+++ b/src/main/java/com/ongil/backend/domain/payment/entity/Payment.java
@@ -56,6 +56,9 @@ public class Payment extends BaseEntity {
 	}
 
 	public void cancelPayment() {
+		if (this.paymentStatus == PaymentStatus.CANCELED) {
+			return;
+		}
 		this.paymentStatus = PaymentStatus.CANCELED;
 		this.canceledAt = LocalDateTime.now();
 	}

--- a/src/main/java/com/ongil/backend/domain/payment/entity/Payment.java
+++ b/src/main/java/com/ongil/backend/domain/payment/entity/Payment.java
@@ -54,4 +54,9 @@ public class Payment extends BaseEntity {
 		this.paymentStatus = paymentStatus;
 		this.order = order;
 	}
+
+	public void cancelPayment() {
+		this.paymentStatus = PaymentStatus.CANCELED;
+		this.canceledAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/ongil/backend/domain/product/entity/ProductOption.java
+++ b/src/main/java/com/ongil/backend/domain/product/entity/ProductOption.java
@@ -40,6 +40,11 @@ public class ProductOption extends BaseEntity {
 		this.stock = stock != null ? stock : 0;
 	}
 
+	// 재고 복원
+	public void restoreStock(int quantity) {
+		this.stock += quantity;
+	}
+
 	// 재고 상태 반환
 	public StockStatus getStockStatus() {
 		return this.stock == 0 ? StockStatus.SOLD_OUT : StockStatus.AVAILABLE;

--- a/src/main/java/com/ongil/backend/domain/product/entity/ProductOption.java
+++ b/src/main/java/com/ongil/backend/domain/product/entity/ProductOption.java
@@ -42,6 +42,9 @@ public class ProductOption extends BaseEntity {
 
 	// 재고 복원
 	public void restoreStock(int quantity) {
+		if (quantity <= 0) {
+			throw new IllegalArgumentException("복원 수량은 양수여야 합니다.");
+		}
 		this.stock += quantity;
 	}
 

--- a/src/main/java/com/ongil/backend/domain/user/entity/User.java
+++ b/src/main/java/com/ongil/backend/domain/user/entity/User.java
@@ -98,6 +98,17 @@ public class User extends BaseEntity {
 		this.bodyInfoAgreed = agreed;
 	}
 
+	// 적립금 복원 비즈니스 로직
+	public void restorePoints(Integer amount) {
+		if (amount == null || amount == 0) return;
+
+		if (amount < 0) {
+			throw new AppException(ErrorCode.INVALID_AMOUNT);
+		}
+
+		this.points += amount;
+	}
+
 	// 적립금 차감 비즈니스 로직
 	public void decreasePoints(Integer amount) {
 		if (amount == null || amount == 0) return;

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
 	INVALID_POINT_USAGE(HttpStatus.BAD_REQUEST, "포인트 사용 금액이 유효하지 않습니다. (0 미만 혹은 결제 금액 초과)", "ORDER-004"),
 	ORDER_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "주문 접수 상태에서만 취소가 가능합니다.", "ORDER-005"),
 	ORDER_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다.", "ORDER-006"),
+	ORDER_UPDATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "주문 접수 상태에서만 변경이 가능합니다.", "ORDER-007"),
 
 	// ADDRESS
 	ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "배송지 정보를 찾을 수 없습니다.", "ADDRESS-001"),

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -60,6 +60,8 @@ public enum ErrorCode {
 	ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 상품을 찾을 수 없습니다.", "ORDER-002"),
 	INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "적립금이 부족합니다.", "ORDER-003"),
 	INVALID_POINT_USAGE(HttpStatus.BAD_REQUEST, "포인트 사용 금액이 유효하지 않습니다. (0 미만 혹은 결제 금액 초과)", "ORDER-004"),
+	ORDER_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "주문 접수 상태에서만 취소가 가능합니다.", "ORDER-005"),
+	ORDER_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다.", "ORDER-006"),
 
 	// ADDRESS
 	ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "배송지 정보를 찾을 수 없습니다.", "ADDRESS-001"),

--- a/src/main/java/com/ongil/backend/global/config/CorsConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/CorsConfig.java
@@ -15,6 +15,8 @@ public class CorsConfig implements WebMvcConfigurer {
 
 	private static final List<String> ALLOWED_ORIGINS = List.of(
 		"https://ongil-fe.vercel.app",
+		"https://ongil.shop",
+		"https://www.ongil.shop",
 		"http://localhost:3000",
 		"http://3.38.199.67:8080",
 		"http://localhost:8080"

--- a/src/main/java/com/ongil/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/SwaggerConfig.java
@@ -38,7 +38,7 @@ public class SwaggerConfig {
 
 		Server server = new Server();
 		if ("prod".equals(profile)) {
-			server.setUrl("http://43.202.164.240");
+			server.setUrl("https://ongil.shop");
 			server.setDescription("운영 서버");
 		} else {
 			server.setUrl("http://localhost:8080");


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
feat: 주문 취소/배송지 변경 API 구현 및 HTTPS 도메인
## ✨ 상세 설명

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  - HTTPS 보안 연결 및 인증서 마운트 지원(포트 443 활성화)
  - Swagger API 문서 경로 및 접근성 추가
  - 정적 프론트엔드 호스팅과 API 프록시 강화
  - 저장된 배송지 조회, 주문 취소·환불 정보 조회, 주문 배송지 변경 및 관련 응답 보강

* **설정**
  - CORS 허용 도메인 추가 및 프로덕션 API 서버 URL 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->