### PR TITLE
feat: S3 연동 프로필 이미지 업로드/삭제 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 
     // Crawling
     implementation 'org.jsoup:jsoup:1.17.2'
+
+    // AWS S3
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.17.2'
 
     // AWS S3
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.1'
 }
 
 dependencyManagement {

--- a/src/main/java/com/ongil/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/ongil/backend/domain/user/controller/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
 	}
 
 	@PatchMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@Operation(summary = "프로필 이미지 수정 API", description = "현재 로그인한 사용자의 프로필 이미지를 수정")
+	@Operation(summary = "프로필 이미지 수정 API", description = "현재 로그인한 사용자의 프로필 이미지를 수정 (토큰 필요)")
 	public ResponseEntity<DataResponse<UserInfoResDto>> updateProfileImage(
 		@AuthenticationPrincipal Long userId,
 		@RequestPart("image") MultipartFile imageFile
@@ -66,7 +66,7 @@ public class UserController {
 	}
 
 	@DeleteMapping("/me/profile-image")
-	@Operation(summary = "프로필 이미지 삭제 API", description = "프로필 이미지를 삭제하고 기본 이미지로 초기화")
+	@Operation(summary = "프로필 이미지 삭제 API", description = "프로필 이미지를 삭제하고 기본 이미지로 초기화 (토큰 필요)")
 	public ResponseEntity<DataResponse<UserInfoResDto>> deleteProfileImage(
 		@AuthenticationPrincipal Long userId
 	) {

--- a/src/main/java/com/ongil/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/ongil/backend/domain/user/controller/UserController.java
@@ -1,18 +1,21 @@
 package com.ongil.backend.domain.user.controller;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.ongil.backend.domain.user.dto.request.BodyInfoRequest;
-import com.ongil.backend.domain.user.dto.request.UserUpdateProfileRequest;
 import com.ongil.backend.domain.user.dto.response.BodyInfoResponse;
 import com.ongil.backend.domain.user.dto.response.SizeOptionsResponse;
 import com.ongil.backend.domain.user.dto.response.TermsResponse;
@@ -52,13 +55,22 @@ public class UserController {
 		return ResponseEntity.ok(DataResponse.from(res));
 	}
 
-	@PatchMapping("/me/profile-image")
+	@PatchMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "프로필 이미지 수정 API", description = "현재 로그인한 사용자의 프로필 이미지를 수정")
 	public ResponseEntity<DataResponse<UserInfoResDto>> updateProfileImage(
 		@AuthenticationPrincipal Long userId,
-		@RequestBody UserUpdateProfileRequest request
+		@RequestPart("image") MultipartFile imageFile
 	) {
-		UserInfoResDto res = userService.updateProfileImage(userId, request.profileImageUrl());
+		UserInfoResDto res = userService.updateProfileImage(userId, imageFile);
+		return ResponseEntity.ok(DataResponse.from(res));
+	}
+
+	@DeleteMapping("/me/profile-image")
+	@Operation(summary = "프로필 이미지 삭제 API", description = "프로필 이미지를 삭제하고 기본 이미지로 초기화")
+	public ResponseEntity<DataResponse<UserInfoResDto>> deleteProfileImage(
+		@AuthenticationPrincipal Long userId
+	) {
+		UserInfoResDto res = userService.deleteProfileImage(userId);
 		return ResponseEntity.ok(DataResponse.from(res));
 	}
 

--- a/src/main/java/com/ongil/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/ongil/backend/domain/user/service/UserService.java
@@ -65,8 +65,9 @@ public class UserService {
 		User user = findUser(userId);
 
 		if (user.getProfileImg() != null) {
-			s3ImageService.delete(user.getProfileImg());
+			String oldImageUrl = user.getProfileImg();
 			user.updateProfileImage(null);
+			s3ImageService.delete(oldImageUrl);
 		}
 
 		return UserConverter.toUserInfoResDto(user);

--- a/src/main/java/com/ongil/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/ongil/backend/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.ongil.backend.domain.user.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.ongil.backend.domain.user.converter.BodyInfoConverter;
 import com.ongil.backend.domain.user.converter.UserConverter;
@@ -17,6 +18,7 @@ import com.ongil.backend.domain.user.enums.TopSize;
 import com.ongil.backend.domain.user.repository.UserRepository;
 import com.ongil.backend.global.common.exception.EntityNotFoundException;
 import com.ongil.backend.global.common.exception.ErrorCode;
+import com.ongil.backend.global.config.s3.S3ImageService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class UserService {
 	private final UserRepository userRepository;
+	private final S3ImageService s3ImageService;
+
 	// 1. 내 정보 조회
 	public UserInfoResDto getUserInfo(Long userId) {
 		User user = userRepository.findById(userId)
@@ -34,11 +38,33 @@ public class UserService {
 	}
 
 	// 2. 프로필 이미지 변경
-	@Transactional // 쓰기 권한 부여
-	public UserInfoResDto updateProfileImage(Long userId, String newImageUrl) {
+	@Transactional
+	public UserInfoResDto updateProfileImage(Long userId, MultipartFile imageFile) {
 		User user = findUser(userId);
 
+		// 기존 프로필 이미지가 있으면 S3에서 삭제
+		if (user.getProfileImg() != null) {
+			s3ImageService.delete(user.getProfileImg());
+		}
+
+		// 새 이미지 S3 업로드
+		String newImageUrl = s3ImageService.upload(imageFile);
+
+		// DB 업데이트
 		user.updateProfileImage(newImageUrl);
+
+		return UserConverter.toUserInfoResDto(user);
+	}
+
+	// 2-1. 프로필 이미지 삭제 (기본 이미지로 초기화)
+	@Transactional
+	public UserInfoResDto deleteProfileImage(Long userId) {
+		User user = findUser(userId);
+
+		if (user.getProfileImg() != null) {
+			s3ImageService.delete(user.getProfileImg());
+			user.updateProfileImage(null);
+		}
 
 		return UserConverter.toUserInfoResDto(user);
 	}

--- a/src/main/java/com/ongil/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/ongil/backend/domain/user/service/UserService.java
@@ -42,16 +42,19 @@ public class UserService {
 	public UserInfoResDto updateProfileImage(Long userId, MultipartFile imageFile) {
 		User user = findUser(userId);
 
-		// 기존 프로필 이미지가 있으면 S3에서 삭제
-		if (user.getProfileImg() != null) {
-			s3ImageService.delete(user.getProfileImg());
-		}
-
-		// 새 이미지 S3 업로드
+		// 1. 새 이미지 먼저 S3 업로드 (실패 시 기존 이미지 보존)
 		String newImageUrl = s3ImageService.upload(imageFile);
 
-		// DB 업데이트
+		// 2. 기존 프로필 이미지 URL 백업
+		String oldImageUrl = user.getProfileImg();
+
+		// 3. DB 업데이트
 		user.updateProfileImage(newImageUrl);
+
+		// 4. 기존 이미지가 있으면 S3에서 삭제
+		if (oldImageUrl != null) {
+			s3ImageService.delete(oldImageUrl);
+		}
 
 		return UserConverter.toUserInfoResDto(user);
 	}

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -83,6 +83,12 @@ public enum ErrorCode {
 
 	// PRICE_ALERT
 	PRICE_ALERT_NOT_FOUND(HttpStatus.NOT_FOUND, "설정된 가격 알림이 없습니다.", "ALERT-001"),
+
+	// FILE / S3
+	FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "파일이 비어 있습니다.", "FILE-001"),
+	INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 확장자입니다. (jpg, jpeg, png만 가능)", "FILE-002"),
+	S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.", "S3-001"),
+	S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다.", "S3-002"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/ongil/backend/global/config/s3/S3ImageService.java
+++ b/src/main/java/com/ongil/backend/global/config/s3/S3ImageService.java
@@ -13,6 +13,7 @@ import com.ongil.backend.global.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -52,7 +53,7 @@ public class S3ImageService {
 
 			s3Client.putObject(putRequest,
 				RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
-		} catch (IOException e) {
+		} catch (IOException | SdkException e) {
 			log.error("S3 업로드 실패: {}", e.getMessage());
 			throw new AppException(ErrorCode.S3_UPLOAD_FAILED);
 		}
@@ -74,7 +75,7 @@ public class S3ImageService {
 
 			s3Client.deleteObject(deleteRequest);
 			log.info("S3 이미지 삭제 완료: {}", key);
-		} catch (Exception e) {
+		} catch (SdkException e) {
 			log.error("S3 이미지 삭제 실패: {}", e.getMessage());
 			throw new AppException(ErrorCode.S3_DELETE_FAILED);
 		}
@@ -104,11 +105,19 @@ public class S3ImageService {
 	 *   -> "profile/abc.jpg"
 	 */
 	private String extractKey(String imageUrl) {
-		String prefix = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
-		return imageUrl.replace(prefix, "");
+		String prefix = generatePrefix();
+		if (!imageUrl.startsWith(prefix)) {
+			log.error("예상 외 이미지 URL 형식: {}", imageUrl);
+			throw new AppException(ErrorCode.S3_DELETE_FAILED);
+		}
+		return imageUrl.substring(prefix.length());
+	}
+
+	private String generatePrefix() {
+		return "https://" + bucket + ".s3." + region + ".amazonaws.com/";
 	}
 
 	private String generateUrl(String key) {
-		return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+		return generatePrefix() + key;
 	}
 }

--- a/src/main/java/com/ongil/backend/global/config/s3/S3ImageService.java
+++ b/src/main/java/com/ongil/backend/global/config/s3/S3ImageService.java
@@ -1,0 +1,114 @@
+package com.ongil.backend.global.config.s3;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ongil.backend.global.common.exception.AppException;
+import com.ongil.backend.global.common.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ImageService {
+
+	private final S3Client s3Client;
+
+	@Value("${spring.cloud.aws.s3.bucket}")
+	private String bucket;
+
+	@Value("${spring.cloud.aws.region.static}")
+	private String region;
+
+	private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png");
+	private static final String PROFILE_DIRECTORY = "profile";
+
+	/**
+	 * 이미지를 S3에 업로드하고 공개 URL을 반환한다.
+	 */
+	public String upload(MultipartFile file) {
+		validateFile(file);
+
+		String extension = extractExtension(file.getOriginalFilename());
+		String key = PROFILE_DIRECTORY + "/" + UUID.randomUUID() + "." + extension;
+
+		try {
+			PutObjectRequest putRequest = PutObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.contentType(file.getContentType())
+				.build();
+
+			s3Client.putObject(putRequest,
+				RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+		} catch (IOException e) {
+			log.error("S3 업로드 실패: {}", e.getMessage());
+			throw new AppException(ErrorCode.S3_UPLOAD_FAILED);
+		}
+
+		return generateUrl(key);
+	}
+
+	/**
+	 * S3에서 기존 이미지를 삭제한다.
+	 */
+	public void delete(String imageUrl) {
+		String key = extractKey(imageUrl);
+
+		try {
+			DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.build();
+
+			s3Client.deleteObject(deleteRequest);
+			log.info("S3 이미지 삭제 완료: {}", key);
+		} catch (Exception e) {
+			log.error("S3 이미지 삭제 실패: {}", e.getMessage());
+			throw new AppException(ErrorCode.S3_DELETE_FAILED);
+		}
+	}
+
+	private void validateFile(MultipartFile file) {
+		if (file == null || file.isEmpty()) {
+			throw new AppException(ErrorCode.FILE_IS_EMPTY);
+		}
+
+		String extension = extractExtension(file.getOriginalFilename());
+		if (!ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
+			throw new AppException(ErrorCode.INVALID_FILE_EXTENSION);
+		}
+	}
+
+	private String extractExtension(String originalFilename) {
+		if (originalFilename == null || !originalFilename.contains(".")) {
+			throw new AppException(ErrorCode.INVALID_FILE_EXTENSION);
+		}
+		return originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
+	}
+
+	/**
+	 * S3 공개 URL에서 key(경로) 부분만 추출한다.
+	 * 예: "https://ongil-bucket.s3.ap-northeast-2.amazonaws.com/profile/abc.jpg"
+	 *   -> "profile/abc.jpg"
+	 */
+	private String extractKey(String imageUrl) {
+		String prefix = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
+		return imageUrl.replace(prefix, "");
+	}
+
+	private String generateUrl(String key) {
+		return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   elasticsearch:
     uris: ${SPRING_ELASTICSEARCH_URIS:http://localhost:9200}
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
   data:
     redis:
       host: ${SPRING_DATA_REDIS_HOST:localhost}
@@ -37,3 +41,12 @@ google:
   redirect-uri: ${GOOGLE_REDIRECT_URI}
   authorization-grant-type: authorization_code
   scope: email, profile
+
+spring.cloud.aws:
+  credentials:
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}
+  region:
+    static: ap-northeast-2
+  s3:
+    bucket: ${AWS_S3_BUCKET}


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
feat: S3 연동 프로필 이미지 업로드/삭제 API 구현
## ✨ 상세 설명

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로필 이미지 업로드 및 삭제 기능 추가(외부 저장 지원)
  * 업로드 폼이 멀티파트로 처리되도록 개선

* **Bug Fixes**
  * 빈 파일 업로드 차단
  * 허용되지 않는 파일 확장자(jpg, jpeg, png만 허용) 차단
  * 파일 업로드 실패/삭제 실패에 대한 오류 응답 개선

* **Chores**
  * 업로드 파일 크기 제한: 최대 5MB 설정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->