### PR TITLE
feat: 배송지 최대 5개 등록 허용 및 삭제/기본배송지 변경 API 추가

### DIFF
--- a/src/main/java/com/ongil/backend/domain/address/controller/AddressController.java
+++ b/src/main/java/com/ongil/backend/domain/address/controller/AddressController.java
@@ -1,6 +1,7 @@
 package com.ongil.backend.domain.address.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,7 +41,7 @@ public class AddressController {
 	}
 
 	@GetMapping("/me")
-	@Operation(summary = "내 배송지 조회", description = "현재 로그인한 사용자의 배송지 정보를 조회합니다.")
+	@Operation(summary = "내 배송지 조회", description = "현재 로그인한 사용자의 배송지 정보를 조회합니다. (토큰 필요)")
 	public DataResponse<ShippingInfoResDto> getShippingInfo(
 		@AuthenticationPrincipal Long userId
 	) {
@@ -49,7 +50,7 @@ public class AddressController {
 	}
 
 	@PostMapping
-	@Operation(summary = "배송지 등록", description = "새로운 배송지를 등록합니다. 기존 배송지가 있으면 삭제 후 등록됩니다.")
+	@Operation(summary = "배송지 등록", description = "새로운 배송지를 등록합니다. 최대 5개까지 등록 가능합니다. (토큰 필요)")
 	public DataResponse<ShippingInfoResDto> createShippingInfo(
 		@AuthenticationPrincipal Long userId,
 		@Valid @RequestBody ShippingInfoCreateReqDto request
@@ -59,7 +60,7 @@ public class AddressController {
 	}
 
 	@PatchMapping("/{addressId}")
-	@Operation(summary = "배송지 수정", description = "기존 배송지 정보를 수정합니다.")
+	@Operation(summary = "배송지 수정", description = "기존 배송지 정보를 수정합니다. (토큰 필요)")
 	public DataResponse<ShippingInfoResDto> updateShippingInfo(
 		@AuthenticationPrincipal Long userId,
 		@PathVariable Long addressId,
@@ -67,5 +68,25 @@ public class AddressController {
 	) {
 		ShippingInfoResDto response = addressService.updateShippingInfo(userId, addressId, request);
 		return DataResponse.from(response);
+	}
+
+	@DeleteMapping("/{addressId}")
+	@Operation(summary = "배송지 삭제", description = "배송지를 삭제합니다. (토큰 필요)")
+	public DataResponse<String> deleteAddress(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long addressId
+	) {
+		addressService.deleteAddress(userId, addressId);
+		return DataResponse.from("배송지가 삭제되었습니다.");
+	}
+
+	@PatchMapping("/{addressId}/default")
+	@Operation(summary = "기본 배송지 설정", description = "해당 배송지를 기본 배송지로 설정합니다. (토큰 필요)")
+	public DataResponse<String> setDefaultAddress(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long addressId
+	) {
+		addressService.setDefaultAddress(userId, addressId);
+		return DataResponse.from("기본 배송지가 변경되었습니다.");
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/address/converter/AddressConverter.java
+++ b/src/main/java/com/ongil/backend/domain/address/converter/AddressConverter.java
@@ -1,6 +1,7 @@
 package com.ongil.backend.domain.address.converter;
 
 import com.ongil.backend.domain.address.dto.request.ShippingInfoCreateReqDto;
+import com.ongil.backend.domain.address.dto.response.AddressListResponse;
 import com.ongil.backend.domain.address.dto.response.ShippingInfoResDto;
 import com.ongil.backend.domain.address.entity.Address;
 import com.ongil.backend.domain.user.entity.User;
@@ -35,7 +36,19 @@ public class AddressConverter {
 			.build();
 	}
 
-	public static Address toEntity(User user, ShippingInfoCreateReqDto request) {
+	public static AddressListResponse toAddressListResponse(Address address) {
+		return new AddressListResponse(
+			address.getId(),
+			address.getRecipientName(),
+			address.getRecipientPhone(),
+			address.getBaseAddress(),
+			address.getDetailAddress(),
+			address.getPostalCode(),
+			address.isDefault()
+		);
+	}
+
+	public static Address toEntity(User user, ShippingInfoCreateReqDto request, boolean isDefault) {
 		return Address.builder()
 			.user(user)
 			.recipientName(request.recipientName())
@@ -44,7 +57,7 @@ public class AddressConverter {
 			.detailAddress(request.detailAddress())
 			.postalCode(request.postalCode())
 			.deliveryRequest(request.deliveryRequest())
-			.isDefault(true)
+			.isDefault(isDefault)
 			.build();
 	}
 

--- a/src/main/java/com/ongil/backend/domain/address/repository/AddressRepository.java
+++ b/src/main/java/com/ongil/backend/domain/address/repository/AddressRepository.java
@@ -9,9 +9,9 @@ import com.ongil.backend.domain.address.entity.Address;
 
 public interface AddressRepository extends JpaRepository<Address, Long> {
 
-	Optional<Address> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+	Optional<Address> findFirstByUserIdOrderByIsDefaultDescCreatedAtDesc(Long userId);
 
 	List<Address> findAllByUserIdOrderByIsDefaultDescCreatedAtDesc(Long userId);
 
-	void deleteAllByUserId(Long userId);
+	long countByUserId(Long userId);
 }

--- a/src/main/java/com/ongil/backend/domain/address/service/AddressService.java
+++ b/src/main/java/com/ongil/backend/domain/address/service/AddressService.java
@@ -18,6 +18,7 @@ import com.ongil.backend.domain.user.repository.UserRepository;
 import com.ongil.backend.global.common.exception.EntityNotFoundException;
 import com.ongil.backend.global.common.exception.ErrorCode;
 import com.ongil.backend.global.common.exception.ForbiddenException;
+import com.ongil.backend.global.common.exception.ValidationException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class AddressService {
 
+	private static final int MAX_ADDRESS_COUNT = 5;
+
 	private final AddressRepository addressRepository;
 	private final UserRepository userRepository;
 
@@ -33,20 +36,12 @@ public class AddressService {
 		List<Address> addresses = addressRepository.findAllByUserIdOrderByIsDefaultDescCreatedAtDesc(userId);
 
 		return addresses.stream()
-			.map(address -> new AddressListResponse(
-				address.getId(),
-				address.getRecipientName(),
-				address.getRecipientPhone(),
-				address.getBaseAddress(),
-				address.getDetailAddress(),
-				address.getPostalCode(),
-				address.isDefault()
-			))
+			.map(AddressConverter::toAddressListResponse)
 			.toList();
 	}
 
 	public ShippingInfoResDto getShippingInfo(Long userId) {
-		Optional<Address> address = addressRepository.findFirstByUserIdOrderByCreatedAtDesc(userId);
+		Optional<Address> address = addressRepository.findFirstByUserIdOrderByIsDefaultDescCreatedAtDesc(userId);
 
 		if (address.isEmpty()) {
 			return ShippingInfoResDto.builder()
@@ -63,11 +58,13 @@ public class AddressService {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 
-		// 기존 배송지 벌크 삭제
-		addressRepository.deleteAllByUserId(userId);
+		long count = addressRepository.countByUserId(userId);
+		if (count >= MAX_ADDRESS_COUNT) {
+			throw new ValidationException(ErrorCode.ADDRESS_LIMIT_EXCEEDED);
+		}
 
-		// 새 배송지 등록
-		Address address = AddressConverter.toEntity(user, request);
+		boolean isDefault = (count == 0);
+		Address address = AddressConverter.toEntity(user, request, isDefault);
 		Address savedAddress = addressRepository.save(address);
 
 		return AddressConverter.toShippingInfoResDto(savedAddress);
@@ -92,5 +89,33 @@ public class AddressService {
 		);
 
 		return AddressConverter.toShippingInfoResDto(address);
+	}
+
+	@Transactional
+	public void deleteAddress(Long userId, Long addressId) {
+		Address address = addressRepository.findById(addressId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.ADDRESS_NOT_FOUND));
+
+		if (!address.getUser().getId().equals(userId)) {
+			throw new ForbiddenException(ErrorCode.ADDRESS_FORBIDDEN);
+		}
+
+		addressRepository.delete(address);
+	}
+
+	@Transactional
+	public void setDefaultAddress(Long userId, Long addressId) {
+		Address address = addressRepository.findById(addressId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.ADDRESS_NOT_FOUND));
+
+		if (!address.getUser().getId().equals(userId)) {
+			throw new ForbiddenException(ErrorCode.ADDRESS_FORBIDDEN);
+		}
+
+		addressRepository.findFirstByUserIdOrderByIsDefaultDescCreatedAtDesc(userId)
+			.filter(Address::isDefault)
+			.ifPresent(current -> current.setDefault(false));
+
+		address.setDefault(true);
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/address/service/AddressService.java
+++ b/src/main/java/com/ongil/backend/domain/address/service/AddressService.java
@@ -100,7 +100,13 @@ public class AddressService {
 			throw new ForbiddenException(ErrorCode.ADDRESS_FORBIDDEN);
 		}
 
+		boolean wasDefault = address.isDefault();
 		addressRepository.delete(address);
+
+		if (wasDefault) {
+			addressRepository.findFirstByUserIdOrderByIsDefaultDescCreatedAtDesc(userId)
+				.ifPresent(next -> next.setDefault(true));
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ongil/backend/global/common/exception/ErrorCode.java
@@ -73,6 +73,7 @@ public enum ErrorCode {
 	// ADDRESS
 	ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "배송지 정보를 찾을 수 없습니다.", "ADDRESS-001"),
 	ADDRESS_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 배송지만 수정/삭제할 수 있습니다.", "ADDRESS-002"),
+	ADDRESS_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "배송지는 최대 5개까지 등록 가능합니다.", "ADDRESS-003"),
 
 	// MAGAZINE
 	MAGAZINE_NOT_FOUND(HttpStatus.NOT_FOUND, "매거진을 찾을 수 없습니다.", "MAG-001"),


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
feat: 배송지 최대 5개 등록 허용 및 삭제/기본배송지 변경 API 추가
## ✨ 상세 설명

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 배송지 삭제 기능 추가
  * 기본 배송지 설정 기능 추가

* **개선 사항**
  * 배송지 목록 조회 시 기본 배송지 우선 표시
  * 배송지 최대 5개까지 등록 제한 및 초과 시 안내 추가
  * API 문서에 인증(토큰) 필요 표시 업데이트

* **버그 수정**
  * 기본 배송지 변경 시 후속 우선순위 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->