### PR TITLE
fix: SecurityConfig에서 불필요한 h2-console permitAll 설정 제거

### DIFF
--- a/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ongil/backend/global/config/SecurityConfig.java
@@ -35,8 +35,8 @@ public class SecurityConfig {
 			.httpBasic(AbstractHttpConfigurer::disable)
 
 			.authorizeHttpRequests(auth -> auth
-				// [1] 시스템 및 문서화 관련 (Swagger, H2 Console)
-				.requestMatchers("/ping", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+				// [1] 시스템 및 문서화 관련 (Swagger)
+				.requestMatchers("/ping", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 
 				// [Admin] 관리자 API (Swagger 테스트용)
 				.requestMatchers("/api/admin/**").permitAll()


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
fix: SecurityConfig에서 불필요한 h2-console permitAll 설정 제거
## ✨ 상세 설명

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **작업**
  * H2 콘솔에 대한 공개 접근이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->