### PR TITLE
[Fix] 카테고리별 사이즈표 타입 필드 추가

### DIFF
--- a/src/main/java/com/ongil/backend/domain/category/entity/Category.java
+++ b/src/main/java/com/ongil/backend/domain/category/entity/Category.java
@@ -3,6 +3,7 @@ package com.ongil.backend.domain.category.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.ongil.backend.domain.category.enums.SizeChartType;
 import com.ongil.backend.global.common.entity.BaseEntity;
 
 import jakarta.persistence.*;
@@ -28,6 +29,10 @@ public class Category extends BaseEntity {
 	@Column(name = "icon_url", length = 500)
 	private String iconUrl;
 
+	@Enumerated(EnumType.STRING)
+	@Column(name = "size_chart_type", length = 20)
+	private SizeChartType sizeChartType;
+
 	@Column(name = "display_order", nullable = false)
 	private Integer displayOrder;
 
@@ -39,15 +44,16 @@ public class Category extends BaseEntity {
 	private List<Category> subCategories = new ArrayList<>();
 
 	@Builder
-	public Category(String name, String iconUrl, Integer displayOrder, Category parentCategory) {
+	public Category(String name, String iconUrl, Integer displayOrder, Category parentCategory, SizeChartType sizeChartType) {
 		this.name = name;
 		this.iconUrl = iconUrl;
 		this.displayOrder = displayOrder;
 		this.parentCategory = parentCategory;
+		this.sizeChartType = sizeChartType;
 	}
 
 	// 카테고리 정보 수정
-	public void updateCategory(String name, String iconUrl, Integer displayOrder, Category parentCategory) {
+	public void updateCategory(String name, String iconUrl, Integer displayOrder, Category parentCategory, SizeChartType sizeChartType) {
 		if (name != null) {
 			this.name = name;
 		}
@@ -65,6 +71,9 @@ public class Category extends BaseEntity {
 				);
 			}
 			this.parentCategory = parentCategory;
+		}
+		if (sizeChartType != null) {
+			this.sizeChartType = sizeChartType;
 		}
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/category/enums/SizeChartType.java
+++ b/src/main/java/com/ongil/backend/domain/category/enums/SizeChartType.java
@@ -1,0 +1,15 @@
+package com.ongil.backend.domain.category.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SizeChartType {
+	TOP_OUTERWEAR("상의 및 아우터"),
+	PANTS("바지"),
+	SKIRT("스커트"),
+	DRESS("원피스");
+
+	private final String description;
+}

--- a/src/main/java/com/ongil/backend/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/ongil/backend/domain/product/converter/ProductConverter.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
+import com.ongil.backend.domain.category.entity.Category;
+import com.ongil.backend.domain.category.enums.SizeChartType;
 import com.ongil.backend.domain.product.dto.response.ProductDetailResponse;
 import com.ongil.backend.domain.product.dto.response.ProductOptionResponse;
 import com.ongil.backend.domain.product.dto.response.ProductSimpleResponse;
@@ -38,6 +40,7 @@ public class ProductConverter {
 			.brandName(product.getBrand().getName())
 			.categoryId(product.getCategory().getId())
 			.categoryName(product.getCategory().getName())
+			.sizeChartType(getSizeChartType(product))
 			.onSale(product.getOnSale())
 			.productType(product.getProductType())
 			.reviewCount(product.getReviewCount())
@@ -149,5 +152,18 @@ public class ProductConverter {
 	private String getFirstImage(String imageUrls) {
 		List<String> images = parseStringToList(imageUrls);
 		return images.isEmpty() ? null : images.get(0);
+	}
+
+	// 사이즈표 타입 가져오기
+	private SizeChartType getSizeChartType(Product product) {
+		Category category = product.getCategory();
+
+		// 하위 카테고리라면 상위 카테고리의 타입 사용
+		if (category.getParentCategory() != null) {
+			return category.getParentCategory().getSizeChartType();
+		}
+
+		// 상위 카테고리라면 자기 자신의 타입 사용
+		return category.getSizeChartType();
 	}
 }

--- a/src/main/java/com/ongil/backend/domain/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/ongil/backend/domain/product/dto/response/ProductDetailResponse.java
@@ -2,6 +2,7 @@ package com.ongil.backend.domain.product.dto.response;
 
 import java.util.List;
 
+import com.ongil.backend.domain.category.enums.SizeChartType;
 import com.ongil.backend.domain.product.enums.ProductType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -59,6 +60,9 @@ public class ProductDetailResponse {
 
 	@Schema(description = "카테고리명")
 	private String categoryName;
+
+	@Schema(description = "사이즈표 타입")
+	private SizeChartType sizeChartType;
 
 	// 상태
 	@Schema(description = "판매 중 여부")


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
카테고리별 사이즈표 타입 필드 추가

## ✨ 상세 설명
  ## ✨ 상세 설명
  - 카테고리별로 사이즈표가 4가지 타입(상의&아우터, 바지, 스커트, 원피스)으로 고정되어 있어, 프론트엔드에서 타입에 맞는 사이즈표 이미지를 매핑하여 표시할 수 있도록 구현했습니다.
  - SizeChartType enum 생성 (TOP_OUTERWEAR, PANTS, SKIRT, DRESS)
  - Category 엔터티에 sizeChartType 필드 추가
  - ProductDetailResponse에 sizeChartType 필드 추가
  - 하위 카테고리는 자동으로 상위 카테고리의 타입을 참조하도록 구현

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 상품의 사이즈 차트 유형 정보 추가
  - 상의 및 아우터, 바지, 스커트, 원피스별로 정확한 사이즈 가이드 제공
  - 카테고리 구조에 따라 자동으로 최적의 사이즈 차트 선택
- 상품 상세 정보에서 해당하는 사이즈 차트 유형 조회 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->