### PR TITLE
refactor: 프로필 이미지 업로드 제한 10MB 변경 및 소셜 로그인 프로필 수정 오류 수정

### DIFF
--- a/src/main/java/com/ongil/backend/global/config/s3/S3ImageService.java
+++ b/src/main/java/com/ongil/backend/global/config/s3/S3ImageService.java
@@ -74,6 +74,11 @@ public class S3ImageService {
 	 * S3에서 기존 이미지를 삭제한다.
 	 */
 	public void delete(String imageUrl) {
+		if (!imageUrl.startsWith(generatePrefix())) {
+			log.info("S3 URL이 아니므로 삭제 생략: {}", imageUrl);
+			return;
+		}
+
 		String key = extractKey(imageUrl);
 
 		try {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,8 @@ spring:
     uris: ${SPRING_ELASTICSEARCH_URIS:http://localhost:9200}
   servlet:
     multipart:
-      max-file-size: 5MB
-      max-request-size: 5MB
+      max-file-size: 10MB
+      max-request-size: 10MB
   data:
     redis:
       host: ${SPRING_DATA_REDIS_HOST:localhost}


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
refactor: 프로필 이미지 업로드 제한 10MB 변경 및 소셜 로그인 프로필 수정 오류 수정
## ✨ 상세 설명

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 이미지 삭제 시 발생할 수 있는 오류 방지

* **개선 사항**
  * 파일 업로드 크기 제한을 5MB에서 10MB로 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->