### PR TITLE
[Fix] 대체검색어 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
 
     // AWS S3
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.1'
+
+    // 대체 검색어 유사도 계산
+    implementation 'org.apache.commons:commons-text:1.12.0'
 }
 
 dependencyManagement {

--- a/src/main/java/com/ongil/backend/domain/search/service/SearchService.java
+++ b/src/main/java/com/ongil/backend/domain/search/service/SearchService.java
@@ -19,10 +19,12 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.text.similarity.LevenshteinDistance;
 
 import co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate;
 import lombok.extern.slf4j.Slf4j;
@@ -67,25 +69,38 @@ public class SearchService {
 		return SearchResDto.of(List.of(), alternatives);
 	}
 
-	public List<String> recommendAlternatives(String keyword, int limit) {
+	public List<String> recommendAlternatives(String keyword, int size) {
 		NativeQuery nativeQuery = NativeQuery.builder()
-			.withQuery(q -> q.fuzzy(f -> f
-				.field("keyword")
-				.value(keyword)
-				.fuzziness("2")
-				.prefixLength(1)
+			.withQuery(q -> q.bool(b -> b
+				.should(s -> s.match(m -> m.field("brandName.autocomplete").query(keyword)))
+				.should(s -> s.match(m -> m.field("categoryName.autocomplete").query(keyword)))
+				.should(s -> s.match(m -> m.field("name.autocomplete").query(keyword)))
 			))
-			.withMinScore(0.1f)
-			.withMaxResults(limit * 2)
+			.withMaxResults(50)
 			.build();
 
-		SearchHits<SearchLogDocument> hits = elasticsearchOperations.search(nativeQuery, SearchLogDocument.class);
+		SearchHits<ProductDocument> hits =
+			elasticsearchOperations.search(nativeQuery, ProductDocument.class);
+
+		LevenshteinDistance levenshtein = new LevenshteinDistance();
+		String lowerKeyword = keyword.toLowerCase();
 
 		return hits.getSearchHits().stream()
-			.map(hit -> hit.getContent().getKeyword())
-			.filter(k -> !k.equals(keyword))
+			.map(hit -> {
+				ProductDocument doc = hit.getContent();
+				List<String> candidates = new ArrayList<>();
+				if (doc.getBrandName() != null) candidates.add(doc.getBrandName());
+				if (doc.getCategoryName() != null) candidates.add(doc.getCategoryName());
+				if (doc.getName() != null) candidates.add(doc.getName());
+				return candidates;
+			})
+			.flatMap(List::stream)
 			.distinct()
-			.limit(limit)
+			.sorted(Comparator.comparingInt(val ->
+				levenshtein.apply(lowerKeyword, val.toLowerCase())
+			))
+			.filter(val -> !val.equalsIgnoreCase(keyword))
+			.limit(size)
 			.toList();
 	}
 


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #145 
* 대체 검색어 로직을 문자 유사도 기반으로 수정

## ✨ 상세 설명
기존 recommendAlternatives는 Elasticsearch Fuzzy Query 기반으로 동작했는데, Fuzzy Query는 영문 기반이라 한글 처리에서 부정확한 문제 존재
- 변경 내용
  - ES는 autocomplete 필드 기반 match query로 후보군(50개)만 수집하는 용도로 변경
  - 실제 유사도 판단은 Java LevenshteinDistance로 처리
  - 후보 키워드(brandName, categoryName, name) 전체를 수집 후 편집거리 순으로 정렬하여 상위 N개 반환
  - commons-text:1.12.0 의존성 추가

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)
<img width="785" height="407" alt="image" src="https://github.com/user-attachments/assets/693b5170-5f5f-4931-bbc7-04a79d956471" />

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 검색 추천 기능에서 유사도 기반 순위 매김 추가
  * 입력한 검색어와 유사한 대체 검색어 제안

* **개선 사항**
  * 여러 필드를 활용한 더 정확한 검색 결과 추천
  * 사용자 입력과의 유사도에 따른 추천 정렬

<!-- end of auto-generated comment: release notes by coderabbit.ai -->