### PR TITLE
[Fix] 소재 프롬프트 수정

### DIFF
--- a/src/main/java/com/ongil/backend/domain/review/service/prompter/MaterialReviewPrompter.java
+++ b/src/main/java/com/ongil/backend/domain/review/service/prompter/MaterialReviewPrompter.java
@@ -1,5 +1,7 @@
 package com.ongil.backend.domain.review.service.prompter;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.ongil.backend.domain.review.dto.request.AiReviewGenerateRequest;
@@ -128,30 +130,38 @@ public class MaterialReviewPrompter implements ReviewPrompter {
 		prompt.append("소재 평가: ").append(request.getMaterialAnswer().getDisplayName()).append("\n");
 
 		if (!request.getMaterialFeatures().isEmpty()) {
-			prompt.append("선택한 소재 특징:\n");
-			boolean hasThicknessAll = false;
+			boolean hasThicknessAll = request.getMaterialFeatures().contains("두께감:선택지전체");
+			List<String> otherFeatures = request.getMaterialFeatures().stream()
+				.filter(f -> !"두께감:선택지전체".equals(f))
+				.toList();
 
-			for (String feature : request.getMaterialFeatures()) {
-				if ("두께감:선택지전체".equals(feature)) {
-					hasThicknessAll = true;
-					continue;
-				}
-				prompt.append("- ").append(feature).append("\n");
-			}
-
-			prompt.append("\n[문장 생성 규칙]");
-			prompt.append("\n1. 위 리스트에 나열된 각 특징마다 서로 다른 느낌의 '2문장씩'을 반드시 생성할 것.");
-
-			if (hasThicknessAll) {
-				prompt.append("\n[특수 지시] 두께감은 아래 3가지 상황에 맞춰 생성하되, 각 문장 사이를 '|' 기호로 구분할 것:\n");
+			// 두께감 전체 선택 단독인 경우
+			if (hasThicknessAll && otherFeatures.isEmpty()) {
+				prompt.append("\n[특수 지시] 두께감만 선택됨. 아래 3가지 상황에 맞춰 각각 1문장씩 생성하되, '|' 기호로 구분할 것:\n");
 				if (isPositive) {
 					prompt.append("1. 두꺼워서 따뜻함 | 2. 얇아서 시원함 | 3. 적당한 두께임\n");
 				} else {
 					prompt.append("1. 소재가 너무 두꺼워서 답답함 | 2. 너무 얇아서 추운 느낌임 | 3. 두께가 애매해서 아쉬움\n");
 				}
+			} else {
+				prompt.append("선택한 소재 특징:\n");
+				for (String feature : otherFeatures) {
+					prompt.append("- ").append(feature).append("\n");
+				}
+
+				prompt.append("\n[문장 생성 규칙]");
+				prompt.append("\n1. 위 리스트에 나열된 각 특징마다 서로 다른 느낌의 '2문장씩'을 반드시 생성할 것.");
+
+				if (hasThicknessAll) {
+					prompt.append("\n[특수 지시] 두께감은 아래 3가지 상황에 맞춰 생성하되, 각 문장 사이를 '|' 기호로 구분할 것:\n");
+					if (isPositive) {
+						prompt.append("1. 두꺼워서 따뜻함 | 2. 얇아서 시원함 | 3. 적당한 두께임\n");
+					} else {
+						prompt.append("1. 소재가 너무 두꺼워서 답답함 | 2. 너무 얇아서 추운 느낌임 | 3. 두께가 애매해서 아쉬움\n");
+					}
+				}
 			}
-		}
-		else {
+		} else {
 			prompt.append("\n[지시] 특정 소재 속성 언급 없이, 전반적으로 무난하고 평범하다는 인상의 서로 다른 '2문장'을 생성할 것.\n");
 		}
 


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #147 

## ✨ 상세 설명
두께감(선택지 전체)만 단독으로 선택했을 때 보풀, 비침 등 관련 없는 소재 속성 문장이 생성되는 문제
- 원인
  - 기존 코드에서 두께감:선택지전체는 continue로 건너뛰어 선택한 소재 특징: 목록이 비어있는 상태가 됨. 그런데 그 아래에 "위 리스트에 나열된 각 특징마다 2문장씩 생성할 것" 규칙이 먼저 등장해, LLM이 리스트가 비어있음에도 시스템 프롬프트의 소재 속성 예시(보풀, 비침 등)를 참고해 스스로 채워버리는 문제 발생
- 변경 내용
  - 두께감 단독 선택 케이스를 별도 분기로 분리

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 소재 리뷰 생성 로직을 최적화하여 선택한 특징에 따라 더욱 정교한 프롬프트를 생성합니다.
  * 두께감 기능 선택 시 전용 처리 방식을 도입하여 더 나은 리뷰 품질을 제공합니다.
  * 다양한 소재 특징 조합에 대응하는 향상된 구조를 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->