### PR TITLE
feat: 상품 목록 응답에 brandId 추가 및 랜덤 카테고리 기본 개수 변경

### DIFF
--- a/src/main/java/com/ongil/backend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/ongil/backend/domain/category/controller/CategoryController.java
@@ -46,7 +46,7 @@ public class CategoryController {
 	@Operation(summary = "랜덤 카테고리 조회", description = "홈 화면용 랜덤 카테고리를 조회합니다. 상품 이미지 포함.")
 	@GetMapping("/random")
 	public DataResponse<List<CategoryRandomResponse>> getRandomCategories(
-		@RequestParam(defaultValue = "8") @Min(1) @Max(100) int count
+		@RequestParam(defaultValue = "4") @Min(1) @Max(100) int count
 	) {
 		List<CategoryRandomResponse> categories = categoryService.getRandomCategories(count);
 		return DataResponse.from(categories);

--- a/src/main/java/com/ongil/backend/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/ongil/backend/domain/product/converter/ProductConverter.java
@@ -62,6 +62,7 @@ public class ProductConverter {
 			.discountRate(product.getDiscountRate())
 			.finalPrice(calculateFinalPrice(product))
 			.thumbnailImageUrl(getFirstImage(product.getImageUrls()))
+			.brandId(product.getBrand().getId())
 			.brandName(product.getBrand().getName())
 			.productType(product.getProductType())
 			.viewCount(product.getViewCount())

--- a/src/main/java/com/ongil/backend/domain/product/dto/response/ProductSimpleResponse.java
+++ b/src/main/java/com/ongil/backend/domain/product/dto/response/ProductSimpleResponse.java
@@ -29,6 +29,9 @@ public class ProductSimpleResponse {
 	@Schema(description = "대표 이미지 URL")
 	private String thumbnailImageUrl;
 
+	@Schema(description = "브랜드 ID")
+	private Long brandId;
+
 	@Schema(description = "브랜드명")
 	private String brandName;
 


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #

## ✨ 상세 설명
- ProductSimpleResponse에 brandId 필드 추가
- ProductConverter.toSimpleResponse()에 brandId 매핑 추가
- GET /categories/random 기본 개수 8 → 4 변경

## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 상품 조회 응답에 브랜드 ID 정보 필드 추가

* **Chores**
  * 무작위 카테고리 조회 기본 반환 개수 조정 (8개 → 4개)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->