### PR TITLE
fix: 할인 알림 설정 방식을 직접 가격 입력에서 할인율 선택으로 변경

### DIFF
--- a/src/main/java/com/ongil/backend/domain/pricealert/dto/request/PriceAlertRequest.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/dto/request/PriceAlertRequest.java
@@ -2,7 +2,6 @@ package com.ongil.backend.domain.pricealert.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 
 @Getter
@@ -13,8 +12,7 @@ public class PriceAlertRequest {
 	@Schema(description = "상품 ID", example = "1")
 	private Long productId;
 
-	@NotNull(message = "목표 가격은 필수입니다.")
-	@Positive(message = "목표 가격은 양수여야 합니다.")
-	@Schema(description = "목표 가격 (사용자가 선택한 할인가)", example = "47500")
-	private Integer targetPrice;
+	@NotNull(message = "할인율은 필수입니다.")
+	@Schema(description = "할인율 (10, 20, 30, 40 중 선택)", example = "20", allowableValues = {"10", "20", "30", "40"})
+	private Integer discountRate;
 }

--- a/src/main/java/com/ongil/backend/domain/pricealert/service/PriceAlertService.java
+++ b/src/main/java/com/ongil/backend/domain/pricealert/service/PriceAlertService.java
@@ -43,9 +43,12 @@ public class PriceAlertService {
 		priceAlertRepository.findByUserIdAndProductIdAndIsActiveTrue(userId, request.getProductId())
 			.ifPresent(PriceAlert::deactivate);
 
+		// 할인율로 목표 가격 계산
+		int targetPrice = product.getPrice() * (100 - request.getDiscountRate()) / 100;
+
 		// 새 건 생성
 		PriceAlert priceAlert = PriceAlert.builder()
-			.targetPrice(request.getTargetPrice())
+			.targetPrice(targetPrice)
 			.isActive(true)
 			.user(user)
 			.product(product)


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
할인 알림 설정 방식을 직접 가격 입력에서 할인율 선택으로 변경

## ✨ 상세 설명
- PriceAlertRequest: targetPrice → discountRate (10/20/30/40%)
- PriceAlertService: 상품 현재가 기반으로 targetPrice 계산 후 저장
 
## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 가격 경고 설정이 목표 가격 기반에서 할인율 기반으로 변경되었습니다.
* 10%, 20%, 30%, 40% 중 원하는 할인율을 선택하여 가격 경고를 생성할 수 있습니다.
* 설정된 할인율에 따라 자동으로 목표 가격이 계산됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->