### PR TITLE
fix: 빈 배열 Redis 캐싱 방지

### DIFF
--- a/src/main/java/com/ongil/backend/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ongil/backend/domain/brand/service/BrandService.java
@@ -23,7 +23,9 @@ import com.ongil.backend.global.config.redis.CacheKeyConstants;
 import com.ongil.backend.global.config.redis.RedisCacheService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -43,13 +45,18 @@ public class BrandService {
 			BrandResponse.class
 		);
 
-		if (cached != null) {
+		if (cached != null && !cached.isEmpty()) {
 			return cached;
 		}
 
 		// Cache Miss → DB 조회
 		List<Brand> brands = brandRepository.findAllOrderByName();
 		List<BrandResponse> response = brandConverter.toResponseList(brands);
+
+		if (response.isEmpty()) {
+			log.warn("조회된 브랜드가 없습니다.");
+			return response;
+		}
 
 		// Redis 캐싱 (무한 TTL)
 		redisCacheService.save(

--- a/src/main/java/com/ongil/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/ongil/backend/domain/category/service/CategoryService.java
@@ -23,7 +23,9 @@ import com.ongil.backend.global.config.redis.CacheKeyConstants;
 import com.ongil.backend.global.config.redis.RedisCacheService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -42,7 +44,7 @@ public class CategoryService {
 			CategoryResponse.class
 		);
 
-		if (cached != null) {
+		if (cached != null && !cached.isEmpty()) {
 			return cached;
 		}
 
@@ -66,6 +68,11 @@ public class CategoryService {
 			})
 			.filter(r -> r != null)
 			.collect(Collectors.toList());
+
+		if (response.isEmpty()) {
+			log.warn("조회된 카테고리가 없습니다.");
+			return response;
+		}
 
 		// Redis 캐싱 (무한 TTL)
 		redisCacheService.save(


### PR DESCRIPTION
## 🔍️ 작업 내용
* Closes #
빈 배열 Redis 캐싱 방지

## ✨ 상세 설명
운영 스웨거에서 브랜드, 카테고리 조회시 빈배열 반환할 경우가 많았습니다. 이를 해결하기 위해 아래처럼 수정했습니다. 

- cached != null 체크를 cached != null && !cached.isEmpty()로 변경
- DB 조회 결과가 빈 배열인 경우 Redis에 저장하지 않도록 수정
- 카테고리/브랜드 전체 조회 API에서 빈 배열이 영구 캐싱되던 문제 해결
## 🛠️ 추후 리팩토링 및 고도화 계획

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 
<!-- 특별히 확인했으면 하는 부분, 궁금한 사항 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Bug Fixes**
  * 브랜드 및 카테고리 조회 시 빈 응답에 대한 처리 개선

* **Chores**
  * 브랜드 및 카테고리 서비스 안정성 강화를 위한 로깅 기능 추가
  * 조회 캐싱 로직 최적화로 불필요한 캐시 저장 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->